### PR TITLE
(Optional PR) Add travisCI support. Need replace with main project info.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ after_success: "make dialyzer"
 branches:
         only:
                 - master
+                - codecov
                 - develop
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: false
+language: erlang
+otp_release:
+       - 18.0
+       - 17.5
+       - 17.4
+       - 17.3
+       - 17.1
+       - 17.0
+cache:
+  directories:
+  - $HOME/.cache/rebar3/hex/default/
+install: "true" # don't let travis run get-deps
+script: "make && make test"
+
+after_success: "make dialyzer"
+
+branches:
+        only:
+                - master
+                - develop
+notifications:
+  email:
+    - example@example.com
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 sudo: false
 language: erlang
-otp_release:
+otp_release:  # travisci complains 17.1 of a 'filelib bug', so excluded
        - 18.0
        - 17.5
        - 17.4
        - 17.3
-       - 17.1
        - 17.0
 cache:
   directories:
@@ -18,8 +17,6 @@ after_success: "make dialyzer"
 branches:
         only:
                 - master
-                - codecov
-                - develop
 notifications:
   email:
     - example@example.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ after_success: "make dialyzer"
 
 branches:
         only:
-                - master
+                - codecov
 notifications:
   email:
     - example@example.com

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/linearregression/gen_rpc.svg)](https://travis-ci.org/linearregression/gen_rpc)
+
 # gen_rpc
 An Erlang/Elixir RPC library for out-of-band messaging
 


### PR DESCRIPTION
Hi,
I added travisci.org support for continuous integration for my personal fork. But a pull request if you want to incorporate to main project.
* any push in master branch will launch a docker container in travisci to install, test etc 
* on different erlang releases 17.x & onwards
But I use my account, so if you want to incorporate this:
* edit readme.md    Build Status link (I use mine linearregression, please replace with project owner)
* .in travis.yml 
      notifications:
      I use example@example.com as a place holder.
      Decide if notification

Ref: http://docs.travis-ci.com