### PR TITLE
Make file fix and add race_conditions in dialyzer build plt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ endif
 # verify that the programs we need to run are installed on this system
 # =============================================================================
 ERL = $(shell which erl)
+TYPER = $(shell which typer)
 
 ifeq ($(ERL),)
 $(error "Erlang not available on this system")
@@ -60,9 +61,9 @@ REBAR = $(CURDIR)/rebar3
 endif
 
 REBAR_URL = https://s3.amazonaws.com/rebar3/rebar3
-TYPER_OPTS = --annotate --annotate-inc-files -I ./include
+TYPER_OPTS = --annotate-inc-files -I ./include
 
-PLT_FILE = $(CURDIR)/_plt/*.plt
+PLT_FILE = $(CURDIR)/_plt/*plt
 
 # =============================================================================
 # Build targets
@@ -81,7 +82,7 @@ xref: $(REBAR)
 	@REBAR_PROFILE=dev $(REBAR) do xref
 
 spec: dialyzer
-	@$(TYPER) $(TYPER_OPTS) --plt $(PLT_FILE) -r src/
+	@$(TYPER) --annotate-inc-files -I ./include --plt $(PLT_FILE) -r src/
 
 dist: $(REBAR) test
 	@REBAR_PROFILE=dev $(REBAR) do dialyzer, xref

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,6 @@ REBAR = $(CURDIR)/rebar3
 endif
 
 REBAR_URL = https://s3.amazonaws.com/rebar3/rebar3
-TYPER_OPTS = --annotate-inc-files -I ./include
 
 PLT_FILE = $(CURDIR)/_plt/*plt
 

--- a/rebar.config
+++ b/rebar.config
@@ -64,7 +64,7 @@
 % Dialyzer
 {dialyzer, [
     {warnings, [no_return, no_unused, no_improper_lists, no_fun_app, no_match, no_opaque, no_fail_call,
-        no_contracts, no_behaviours, no_undefined_callbacks, unmatched_returns, error_handling,
+        no_contracts, no_behaviours, no_undefined_callbacks, unmatched_returns, error_handling, race_conditions,
         overspecs, underspecs, specdiffs]},
     {get_warnings, true},
     {plt_location, "_plt"},


### PR DESCRIPTION
env:   erlang 18
          rebar 18.0.3 
          ubuntu 13
Makefile:
* spec: refers to $(TYPER), but not set before hand. Now set and check typer exists
* $TYOPTS: 'annotate_inc_files already includes annotate and it errors out typer.

    ** typer: Mode was previously set to 'annotate'; can not set it to 'annotate_inc_files' now

    ** Unable to interpret that as options ! /bin/sh  --annotate not found
* plt file name mismatch

         ** ===> Analyzing 11 files with "_plt/rebar3_18.0.3_plt"...<-- tool defaults to this file
*  turn on race_conditions in dialyzer build plt