### PR TITLE
looks like rpc spec returns {badrpc, Reason}. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script: "make test xref dialyzer"
 branches:
   only:
     - master
+    - presjimbench
 notifications:
   email:
     - priestjim@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script: "make test xref dialyzer"
 branches:
   only:
     - master
-    - presjimbench
 notifications:
   email:
     - priestjim@gmail.com

--- a/include/app.hrl
+++ b/include/app.hrl
@@ -17,6 +17,4 @@
         {tos,72}, % Deliver immediately
         {active,false}]). % Retrieve data from socket upon request
 
--type socket_setopt() ::
-        gen_sctp:option() | gen_tcp:option() | gen_udp:option().
 

--- a/src/gen_rpc.erl
+++ b/src/gen_rpc.erl
@@ -24,42 +24,42 @@
 %%% ===================================================
 %% All functions are GUARD-ed in the sender module, no
 %% need for the overhead here
--spec call(Node::node(), M::module(), F::function()) -> term().
+-spec call(Node::node(), M::module(), F::atom()|function()) -> term().
 call(Node, M, F) ->
     gen_rpc_client:call(Node, M, F).
 
--spec call(Node::node(), M::module(), F::function(), A::list()) -> term().
+-spec call(Node::node(), M::module(), F::atom()|function(), A::list()) -> term().
 call(Node, M, F, A) ->
     gen_rpc_client:call(Node, M, F, A).
 
--spec call(Node::node(), M::module(), F::function(), A::list(), RecvTO::timeout()) -> term().
+-spec call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout()) -> term().
 call(Node, M, F, A, RecvTO) ->
     gen_rpc_client:call(Node, M, F, A, RecvTO).
 
--spec call(Node::node(), M::module(), F::function(), A::list(), RecvTO::timeout(), SendTO::timeout()) -> term().
+-spec call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout(), SendTO::timeout()) -> term().
 call(Node, M, F, A, RecvTO, SendTO) ->
     gen_rpc_client:call(Node, M, F, A, RecvTO, SendTO).
 
--spec cast(Node::node(), M::module(), F::function()) -> 'true'.
+-spec cast(Node::node(), M::module(), F::atom()|function()) -> 'true'.
 cast(Node, M, F) ->
     gen_rpc_client:cast(Node, M, F).
 
--spec cast(Node::node(), M::module(), F::function(), A::list()) -> 'true'.
+-spec cast(Node::node(), M::module(), F::atom()|function(), A::list()) -> 'true'.
 cast(Node, M, F, A) ->
     gen_rpc_client:cast(Node, M, F, A).
 
--spec cast(Node::node(), M::module(), F::function(), A::list(), SendTO::timeout()) -> 'true'.
+-spec cast(Node::node(), M::module(), F::atom()|function(), A::list(), SendTO::timeout()) -> 'true'.
 cast(Node, M, F, A, SendTO) ->
     gen_rpc_client:cast(Node, M, F, A, SendTO).
 
--spec safe_cast(Node::node(), M::module(), F::function()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
+-spec safe_cast(Node::node(), M::module(), F::atom()|function()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F) ->
     gen_rpc_client:safe_cast(Node, M, F).
 
--spec safe_cast(Node::node(), M::module(), F::function(), A::list()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
+-spec safe_cast(Node::node(), M::module(), F::atom()|function(), A::list()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F, A) ->
     gen_rpc_client:safe_cast(Node, M, F, A).
 
--spec safe_cast(Node::node(), M::module(), F::function(), A::list(), SendTO::timeout()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
+-spec safe_cast(Node::node(), M::module(), F::atom()|function(), A::list(), SendTO::timeout()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F, A, SendTO) ->
     gen_rpc_client:safe_cast(Node, M, F, A, SendTO).

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -201,5 +201,6 @@ call_worker(Parent, WorkerPid, Ref, M, F, A) ->
                {'EXIT', _} = V -> {badrpc, V};
                Else -> Else
           end,
-    PacketBin = erlang:term_to_binary({WorkerPid, Ref, Ret}),    Parent ! {call_reply, PacketBin},
+    PacketBin = erlang:term_to_binary({WorkerPid, Ref, Ret}),
+    Parent ! {call_reply, PacketBin},
     ok.

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -197,7 +197,9 @@ call_worker(Parent, WorkerPid, Ref, M, F, A) ->
     % and manifest as timeout. Wrap inside anonymous function with catch
     % will crash the worker quickly not manifest as a timeout.
     % See call_MFA_undef test.
-    % Fun = fun() -> catch erlang:apply(M, F, A) end,
-    PacketBin = erlang:term_to_binary({WorkerPid, Ref, catch erlang:apply(M, F, A)}),
-    Parent ! {call_reply, PacketBin},
+    Ret = case catch erlang:apply(M, F, A)of
+               {'EXIT', _} = V -> {badrpc, V};
+               Else -> Else
+          end,
+    PacketBin = erlang:term_to_binary({WorkerPid, Ref, Ret}),    Parent ! {call_reply, PacketBin},
     ok.

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -197,11 +197,9 @@ call_worker(Parent, WorkerPid, Ref, M, F, A) ->
     % and manifest as timeout. Wrap inside anonymous function with catch
     % will crash the worker quickly not manifest as a timeout.
     % See call_MFA_undef test.
-    Ret = try erlang:apply(M, F, A)
-          catch
-               throw:Term -> {badrpc, Term};
-               exit:Reason -> {badrpc, Reason};
-               error:Reason -> {badrpc, {'EXIT',{Reason, erlang:get_stacktrace()}}}
+    Ret = case catch erlang:apply(M, F, A)of
+               {'EXIT', _} = V -> {badrpc, V};
+               Else -> Else
           end,
     PacketBin = erlang:term_to_binary({WorkerPid, Ref, Ret}),
     Parent ! {call_reply, PacketBin},

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -197,9 +197,11 @@ call_worker(Parent, WorkerPid, Ref, M, F, A) ->
     % and manifest as timeout. Wrap inside anonymous function with catch
     % will crash the worker quickly not manifest as a timeout.
     % See call_MFA_undef test.
-    Ret = case catch erlang:apply(M, F, A)of
-               {'EXIT', _} = V -> {badrpc, V};
-               Else -> Else
+    Ret = try erlang:apply(M, F, A)
+          catch
+               throw:Term -> {badrpc, Term};
+               exit:Reason -> {badrpc, Reason};
+               error:Reason -> {badrpc, {'EXIT',{Reason, erlang:get_stacktrace()}}}
           end,
     PacketBin = erlang:term_to_binary({WorkerPid, Ref, Ret}),
     Parent ! {call_reply, PacketBin},

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -197,9 +197,15 @@ call_worker(Parent, WorkerPid, Ref, M, F, A) ->
     % and manifest as timeout. Wrap inside anonymous function with catch
     % will crash the worker quickly not manifest as a timeout.
     % See call_MFA_undef test.
-    Ret = case catch erlang:apply(M, F, A)of
-               {'EXIT', _} = V -> {badrpc, V};
-               Else -> Else
+   % Ret = case catch erlang:apply(M, F, A) of
+   %            {'EXIT', _} = V -> {badrpc, V};
+   %            Else -> Else
+   %       end,
+    Ret = try erlang:apply(M, F, A) 
+          catch 
+               throw:Term -> {badrpc, {'EXIT', Term}};
+               exit:Reason -> {badrpc, {'EXIT', Reason}};
+               error:Reason -> {badrpc, {'EXIT', Reason, erlang:get_stacktrace()}}
           end,
     PacketBin = erlang:term_to_binary({WorkerPid, Ref, Ret}),
     Parent ! {call_reply, PacketBin},

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -205,7 +205,7 @@ call_worker(Parent, WorkerPid, Ref, M, F, A) ->
           catch 
                throw:Term -> {badrpc, {'EXIT', Term}};
                exit:Reason -> {badrpc, {'EXIT', Reason}};
-               error:Reason -> {badrpc, {'EXIT', Reason, erlang:get_stacktrace()}}
+               error:Reason -> {badrpc, {'EXIT', {Reason, erlang:get_stacktrace()}}}
           end,
     PacketBin = erlang:term_to_binary({WorkerPid, Ref, Ret}),
     Parent ! {call_reply, PacketBin},

--- a/src/gen_rpc_app.erl
+++ b/src/gen_rpc_app.erl
@@ -35,7 +35,8 @@ stop(_State) ->
 %%% ===================================================
 -spec start() -> 'ok' | {'error', term()}.
 start() ->
-    application:start(?APP).
+    application:ensure_all_started(?APP),
+    start(normal, []).
 
 -spec stop() -> 'ok' | {'error', term()}.
 stop() ->

--- a/src/gen_rpc_app.erl
+++ b/src/gen_rpc_app.erl
@@ -35,8 +35,7 @@ stop(_State) ->
 %%% ===================================================
 -spec start() -> 'ok' | {'error', term()}.
 start() ->
-    application:ensure_all_started(?APP),
-    start(normal, []).
+    application:start(?APP).
 
 -spec stop() -> 'ok' | {'error', term()}.
 stop() ->

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -50,20 +50,24 @@ stop(Node) when is_atom(Node) ->
 %%% Server functions
 %%% ===================================================
 %% Simple server call with no args and default timeout values
+-spec call(Node::node(), M::module(), F::atom()|function()) -> term().
 call(Node, M, F) when is_atom(Node), is_atom(M), is_atom(F) ->
     call(Node, M, F, [], undefined, undefined).
 
 %% Simple server call with args and default timeout values
+-spec call(Node::node(), M::module(), F::atom()|function(), A::list()) -> term().
 call(Node, M, F, A) when is_atom(Node), is_atom(M), is_atom(F), is_list(A) ->
     call(Node, M, F, A, undefined, undefined).
 
 %% Simple server call with custom receive timeout value
+-spec call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout()) -> term().
 call(Node, M, F, A, RecvTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(A),
                                  is_integer(RecvTO) orelse RecvTO =:= infinity ->
     call(Node, M, F, A, RecvTO, undefined).
 
 %% Simple server call with custom receive and send timeout values
 %% This is the function that all of the above call
+-spec call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout(), SendTO::timeout()) -> term().
 call(Node, M, F, A, RecvTO, SendTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(A),
                                          RecvTO =:= undefined orelse is_integer(RecvTO) orelse RecvTO =:= infinity,
                                          SendTO =:= undefined orelse is_integer(SendTO) orelse SendTO =:= infinity ->
@@ -85,15 +89,18 @@ call(Node, M, F, A, RecvTO, SendTO) when is_atom(Node), is_atom(M), is_atom(F), 
     end.
 
 %% Simple server cast with no args and default timeout values
+-spec cast(Node::node(), M::module(), F::atom()|function()) -> 'true'.
 cast(Node, M, F) when is_atom(Node), is_atom(M), is_atom(F) ->
     cast(Node, M, F, [], undefined).
 
 %% Simple server cast with args and default timeout values
+-spec cast(Node::node(), M::module(), F::atom()|function(), A::list()) -> 'true'.
 cast(Node, M, F, A) when is_atom(Node), is_atom(M), is_atom(F), is_list(A) ->
     cast(Node, M, F, A, undefined).
 
 %% Simple server cast with custom send timeout value
 %% This is the function that all of the above casts call
+-spec cast(Node::node(), M::module(), F::atom()|function(), A::list(), SendTO::timeout()) -> 'true'.
 cast(Node, M, F, A, SendTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(A),
                                  SendTO =:= undefined orelse is_integer(SendTO) orelse SendTO =:= infinity ->
     %% Naming our gen_server as the node we're calling as it is extremely efficent:
@@ -118,15 +125,18 @@ cast(Node, M, F, A, SendTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(
     end.
 
 %% Safe server cast with no args and default timeout values
+-spec safe_cast(Node::node(), M::module(), F::atom()|function()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F) when is_atom(Node), is_atom(M), is_atom(F) ->
     safe_cast(Node, M, F, [], undefined).
 
 %% Safe server cast with args and default timeout values
+-spec safe_cast(Node::node(), M::module(), F::atom()|function(), A::list()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F, A) when is_atom(Node), is_atom(M), is_atom(F), is_list(A) ->
     safe_cast(Node, M, F, A, undefined).
 
 %% Safe server cast with custom send timeout value
 %% This is the function that all of the above casts call
+-spec safe_cast(Node::node(), M::module(), F::atom()|function(), A::list(), SendTO::timeout()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F, A, SendTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(A),
                                  SendTO =:= undefined orelse is_integer(SendTO) orelse SendTO =:= infinity ->
     %% Naming our gen_server as the node we're calling as it is extremely efficent:

--- a/test/gen_rpc/functional_SUITE.erl
+++ b/test/gen_rpc/functional_SUITE.erl
@@ -20,17 +20,20 @@
         call_anonymous_undef/1,
         call_mfa_undef/1,
         call_mfa_exit/1,
+        call_mfa_throw/1,
         call_with_receive_timeout/1,
         interleaved_call/1,
         cast/1,
         cast_anonymous_function/1,
         cast_mfa_undef/1,
         cast_mfa_exit/1,
+        cast_mfa_throw/1,
         cast_inexistent_node/1,
         safe_cast/1,
         safe_cast_anonymous_function/1,
         safe_cast_mfa_undef/1,
         safe_cast_mfa_exit/1,
+        safe_cast_mfa_throw/1,
         safe_cast_inexistent_node/1,
         client_inactivity_timeout/1,
         server_inactivity_timeout/1,
@@ -118,17 +121,22 @@ call_anonymous_function(_Config) ->
 
 call_anonymous_undef(_Config) ->
     ok = ct:pal("Testing [call_anonymous_undef]"),
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {badrpc, {'EXIT', undef,[{os,timestamp_undef,_,_},_]}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
     ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [call_mfa_undef]"),
-    {badrpc, {'EXIT',{undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, os, timestamp_undef),
+    {badrpc, {'EXIT', undef,[{os,timestamp_undef,_,_},_]}} = gen_rpc:call(?NODE, os, timestamp_undef),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_exit(_Config) ->
     ok = ct:pal("Testing [call_mfa_exit]"),
-    {badrpc, {'EXIT', die}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> exit(die) end, []]),
+    {badrpc, {'EXIT',die}} = gen_rpc:call(?NODE, erlang, exit, ['die']),
+    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
+
+call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [call_mfa_throw]"),
+    {badrpc, {'EXIT', 'throwme'}} = gen_rpc:call(?NODE, erlang, throw, ['throwme']),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
 
 call_with_receive_timeout(_Config) ->
@@ -164,6 +172,10 @@ cast_mfa_exit(_Config) ->
     ok = ct:pal("Testing [cast_mfa_exit]"),
     true = gen_rpc:cast(?NODE, erlang, apply, [fun() -> exit(die) end, []]).
 
+cast_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [cast_mfa_throw]"),
+    true = gen_rpc:cast(?NODE, erlang, throw, ['throwme']).
+
 cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [cast_inexistent_node]"),
     true = gen_rpc:cast(?FAKE_NODE, os, timestamp, []).
@@ -183,6 +195,10 @@ safe_cast_mfa_undef(_Config) ->
 safe_cast_mfa_exit(_Config) ->
     ok = ct:pal("Testing [safe_cast_mfa_exit]"),
     true = gen_rpc:safe_cast(?NODE, erlang, apply, [fun() -> exit(die) end, []]).
+
+safe_cast_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [safe_cast_mfa_throw]"),
+    true = gen_rpc:safe_cast(?NODE, erlang, throw, ['throwme']).
 
 safe_cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [safe_cast_inexistent_node]"),

--- a/test/gen_rpc/functional_SUITE.erl
+++ b/test/gen_rpc/functional_SUITE.erl
@@ -118,17 +118,17 @@ call_anonymous_function(_Config) ->
 
 call_anonymous_undef(_Config) ->
     ok = ct:pal("Testing [call_anonymous_undef]"),
-    {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
     ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [call_mfa_undef]"),
-    {'EXIT',{undef,[{os,timestamp_undef,_,_},_]}} = gen_rpc:call(?NODE, os, timestamp_undef),
+    {badrpc, {'EXIT',{undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, os, timestamp_undef),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_exit(_Config) ->
     ok = ct:pal("Testing [call_mfa_exit]"),
-    {'EXIT', die} = gen_rpc:call(?NODE, erlang, apply, [fun() -> exit(die) end, []]),
+    {badrpc, {'EXIT', die}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> exit(die) end, []]),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
 
 call_with_receive_timeout(_Config) ->

--- a/test/gen_rpc/functional_SUITE.erl
+++ b/test/gen_rpc/functional_SUITE.erl
@@ -121,12 +121,12 @@ call_anonymous_function(_Config) ->
 
 call_anonymous_undef(_Config) ->
     ok = ct:pal("Testing [call_anonymous_undef]"),
-    {badrpc, {'EXIT', undef,[{os,timestamp_undef,_,_},_]}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {badrpc, {'EXIT',{undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
     ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [call_mfa_undef]"),
-    {badrpc, {'EXIT', undef,[{os,timestamp_undef,_,_},_]}} = gen_rpc:call(?NODE, os, timestamp_undef),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, os, timestamp_undef),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_exit(_Config) ->


### PR DESCRIPTION
* remove uneeded spec type since support only tcp now.
* type spec for F in MFA. For anonymous function the type is function. but for exported funciton it is atom()
* rpc returns Result | {badrpc, Reason}. 
  On exception, they are not always returned as {badrpc, Reason}.
  Want to bypass gen_rpc call if targetNode is itself?