### PR TITLE
Fix return to be as close to rpc as possible

### DIFF
--- a/src/gen_rpc.erl
+++ b/src/gen_rpc.erl
@@ -24,42 +24,42 @@
 %%% ===================================================
 %% All functions are GUARD-ed in the sender module, no
 %% need for the overhead here
--spec call(Node::node(), M::module(), F::function()) -> term().
+-spec call(Node::node(), M::module(), F::atom()|function()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
 call(Node, M, F) ->
     gen_rpc_client:call(Node, M, F).
 
--spec call(Node::node(), M::module(), F::function(), A::list()) -> term().
+-spec call(Node::node(), M::module(), F::atom()|function(), A::list()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
 call(Node, M, F, A) ->
     gen_rpc_client:call(Node, M, F, A).
 
--spec call(Node::node(), M::module(), F::function(), A::list(), RecvTO::timeout()) -> term().
+-spec call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
 call(Node, M, F, A, RecvTO) ->
     gen_rpc_client:call(Node, M, F, A, RecvTO).
 
--spec call(Node::node(), M::module(), F::function(), A::list(), RecvTO::timeout(), SendTO::timeout()) -> term().
+-spec call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout(), SendTO::timeout()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
 call(Node, M, F, A, RecvTO, SendTO) ->
     gen_rpc_client:call(Node, M, F, A, RecvTO, SendTO).
 
--spec cast(Node::node(), M::module(), F::function()) -> 'true'.
+-spec cast(Node::node(), M::module(), F::atom()|function()) -> 'true'.
 cast(Node, M, F) ->
     gen_rpc_client:cast(Node, M, F).
 
--spec cast(Node::node(), M::module(), F::function(), A::list()) -> 'true'.
+-spec cast(Node::node(), M::module(), F::atom()|function(), A::list()) -> 'true'.
 cast(Node, M, F, A) ->
     gen_rpc_client:cast(Node, M, F, A).
 
--spec cast(Node::node(), M::module(), F::function(), A::list(), SendTO::timeout()) -> 'true'.
+-spec cast(Node::node(), M::module(), F::atom()|function(), A::list(), SendTO::timeout()) -> 'true'.
 cast(Node, M, F, A, SendTO) ->
     gen_rpc_client:cast(Node, M, F, A, SendTO).
 
--spec safe_cast(Node::node(), M::module(), F::function()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
+-spec safe_cast(Node::node(), M::module(), F::atom()|function()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F) ->
     gen_rpc_client:safe_cast(Node, M, F).
 
--spec safe_cast(Node::node(), M::module(), F::function(), A::list()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
+-spec safe_cast(Node::node(), M::module(), F::atom()|function(), A::list()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F, A) ->
     gen_rpc_client:safe_cast(Node, M, F, A).
 
--spec safe_cast(Node::node(), M::module(), F::function(), A::list(), SendTO::timeout()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
+-spec safe_cast(Node::node(), M::module(), F::atom()|function(), A::list(), SendTO::timeout()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F, A, SendTO) ->
     gen_rpc_client:safe_cast(Node, M, F, A, SendTO).

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -197,10 +197,7 @@ call_worker(Parent, WorkerPid, Ref, M, F, A) ->
     % and manifest as timeout. Wrap inside anonymous function with catch
     % will crash the worker quickly not manifest as a timeout.
     % See call_MFA_undef test.
-   % Ret = case catch erlang:apply(M, F, A) of
-   %            {'EXIT', _} = V -> {badrpc, V};
-   %            Else -> Else
-   %       end,
+    % rpc hides throw. We marked throw same as exit.
     Ret = try erlang:apply(M, F, A) 
           catch 
                throw:Term -> {badrpc, {'EXIT', Term}};

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -197,10 +197,9 @@ call_worker(Parent, WorkerPid, Ref, M, F, A) ->
     % and manifest as timeout. Wrap inside anonymous function with catch
     % will crash the worker quickly not manifest as a timeout.
     % See call_MFA_undef test.
-    % rpc hides throw. We marked throw same as exit.
     Ret = try erlang:apply(M, F, A) 
           catch 
-               throw:Term -> {badrpc, {'EXIT', Term}};
+               throw:Term -> Term;
                exit:Reason -> {badrpc, {'EXIT', Reason}};
                error:Reason -> {badrpc, {'EXIT', {Reason, erlang:get_stacktrace()}}}
           end,

--- a/src/gen_rpc_helper.erl
+++ b/src/gen_rpc_helper.erl
@@ -24,7 +24,7 @@ otp_release() ->
             16
     end.
 
-%-spec default_tcp_opts() -> gen_rpc_tcp_opts().
+-spec default_tcp_opts(gen_tcp:option()) ->  gen_tcp:option().
 default_tcp_opts(DefaultTcpOpts) ->
     case otp_release() >= 18 of
         true ->
@@ -32,4 +32,5 @@ default_tcp_opts(DefaultTcpOpts) ->
         false ->
             DefaultTcpOpts
     end.
+
 

--- a/test/gen_rpc/functional_SUITE.erl
+++ b/test/gen_rpc/functional_SUITE.erl
@@ -20,17 +20,20 @@
         call_anonymous_undef/1,
         call_mfa_undef/1,
         call_mfa_exit/1,
+        call_mfa_throw/1,
         call_with_receive_timeout/1,
         interleaved_call/1,
         cast/1,
         cast_anonymous_function/1,
         cast_mfa_undef/1,
         cast_mfa_exit/1,
+        cast_mfa_throw/1,
         cast_inexistent_node/1,
         safe_cast/1,
         safe_cast_anonymous_function/1,
         safe_cast_mfa_undef/1,
         safe_cast_mfa_exit/1,
+        safe_cast_mfa_throw/1,
         safe_cast_inexistent_node/1,
         client_inactivity_timeout/1,
         server_inactivity_timeout/1,
@@ -118,17 +121,22 @@ call_anonymous_function(_Config) ->
 
 call_anonymous_undef(_Config) ->
     ok = ct:pal("Testing [call_anonymous_undef]"),
-    {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {badrpc, {'EXIT',{undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
     ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [call_mfa_undef]"),
-    {'EXIT',{undef,[{os,timestamp_undef,_,_},_]}} = gen_rpc:call(?NODE, os, timestamp_undef),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, os, timestamp_undef),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_exit(_Config) ->
     ok = ct:pal("Testing [call_mfa_exit]"),
-    {'EXIT', die} = gen_rpc:call(?NODE, erlang, apply, [fun() -> exit(die) end, []]),
+    {badrpc, {'EXIT',die}} = gen_rpc:call(?NODE, erlang, exit, ['die']),
+    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
+
+call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [call_mfa_throw]"),
+    {badrpc, {'EXIT', 'throwme'}} = gen_rpc:call(?NODE, erlang, throw, ['throwme']),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
 
 call_with_receive_timeout(_Config) ->
@@ -164,6 +172,10 @@ cast_mfa_exit(_Config) ->
     ok = ct:pal("Testing [cast_mfa_exit]"),
     true = gen_rpc:cast(?NODE, erlang, apply, [fun() -> exit(die) end, []]).
 
+cast_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [cast_mfa_throw]"),
+    true = gen_rpc:cast(?NODE, erlang, throw, ['throwme']).
+
 cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [cast_inexistent_node]"),
     true = gen_rpc:cast(?FAKE_NODE, os, timestamp, []).
@@ -183,6 +195,10 @@ safe_cast_mfa_undef(_Config) ->
 safe_cast_mfa_exit(_Config) ->
     ok = ct:pal("Testing [safe_cast_mfa_exit]"),
     true = gen_rpc:safe_cast(?NODE, erlang, apply, [fun() -> exit(die) end, []]).
+
+safe_cast_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [safe_cast_mfa_throw]"),
+    true = gen_rpc:safe_cast(?NODE, erlang, throw, ['throwme']).
 
 safe_cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [safe_cast_inexistent_node]"),

--- a/test/gen_rpc/functional_SUITE.erl
+++ b/test/gen_rpc/functional_SUITE.erl
@@ -121,7 +121,7 @@ call_anonymous_function(_Config) ->
 
 call_anonymous_undef(_Config) ->
     ok = ct:pal("Testing [call_anonymous_undef]"),
-    {badrpc, {'EXIT',{undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
     ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_undef(_Config) ->
@@ -131,12 +131,12 @@ call_mfa_undef(_Config) ->
 
 call_mfa_exit(_Config) ->
     ok = ct:pal("Testing [call_mfa_exit]"),
-    {badrpc, {'EXIT',die}} = gen_rpc:call(?NODE, erlang, exit, ['die']),
+    {badrpc, {'EXIT', die}} = gen_rpc:call(?NODE, erlang, exit, ['die']),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
 
 call_mfa_throw(_Config) ->
     ok = ct:pal("Testing [call_mfa_throw]"),
-    {badrpc, {'EXIT', 'throwme'}} = gen_rpc:call(?NODE, erlang, throw, ['throwme']),
+    {badrpc, {'EXIT', 'throwXdown'}} = gen_rpc:call(?NODE, erlang, throw, ['throwXdown']),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
 
 call_with_receive_timeout(_Config) ->

--- a/test/gen_rpc/functional_SUITE.erl
+++ b/test/gen_rpc/functional_SUITE.erl
@@ -136,7 +136,7 @@ call_mfa_exit(_Config) ->
 
 call_mfa_throw(_Config) ->
     ok = ct:pal("Testing [call_mfa_throw]"),
-    {badrpc, {'EXIT', 'throwXdown'}} = gen_rpc:call(?NODE, erlang, throw, ['throwXdown']),
+    'throwXdown' = gen_rpc:call(?NODE, erlang, throw, ['throwXdown']),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
 
 call_with_receive_timeout(_Config) ->


### PR DESCRIPTION
* rpc returns Result | {badrpc, Reason}. On exception, they are not always returned as {badrpc, Reason}.
* rpc does not distinguish between throw:something vs a true return something (see Ref).  
  Now  try/catch throw is marked as badrpc (so this is different from rpc behaviour). So looks like cleaner  but a chance to change hiding throw.
* I only incude stackstrace in error (see second ref) I don't know how the cost manifest.

Ref:
http://www.erlang.org/workshop/2004/exception.pdf
http://erlang.org/pipermail/erlang-questions/2013-November/075928.html