### PR TITLE
Call locally if target node is itself (experimental)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ distclean: $(REBAR)
 	@$(REBAR) clean -a
 
 testclean:
+	@rm -fr _build/test && rm -rf ./test/*.beam
 	@find log/ct -maxdepth 1 -name ct_run* -type d -cmin +360 -exec rm -fr {} \;
-	@rm -fr _build/test
 
 epmd:
 	@pgrep epmd 2> /dev/null > /dev/null || epmd -daemon || true

--- a/rebar.config
+++ b/rebar.config
@@ -57,7 +57,8 @@
     {suites, "test", all},
     {cover,"test/gen_rpc.coverspec"},
     {suite, [
-        functional_SUITE
+        local_functional_SUITE,
+        remote_functional_SUITE
     ]}
 ]}.
 

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -64,8 +64,9 @@ call(Node, M, F, A, RecvTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(
 
 %% Simple server call with custom receive and send timeout values
 %% This is the function that all of the above call
-%% Target is itself
-call(Node, M, F, A, infinity, infinity) when node() =:= Node, is_atom(F), is_list(A)->
+%% Target is itself. Sender/Receiver are the same guy.
+call(Node, M, F, A, Timeout, Timeout) when node() =:= Node, is_atom(M), is_atom(F), is_list(A),
+                                         Timeout =:= undefined orelse is_integer(Timeout) orelse Timeout =:= infinity ->
     local_call(M,F,A);
 %% Target is a non local node
 call(Node, M, F, A, RecvTO, SendTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(A),
@@ -98,9 +99,10 @@ cast(Node, M, F, A) when is_atom(Node), is_atom(M), is_atom(F), is_list(A) ->
 
 %% Simple server cast with custom send timeout value
 %% This is the function that all of the above casts call
-%% Target is itself
-cast(Node, M, F, A, SendTO) when node =:= Node, is_atom(F), is_list(A),
-                                 SendTO =:= undefined orelse is_integer(SendTO) orelse SendTO =:= infinity ->
+%% Target is itself.
+cast(Node, M, F, A, undefined) when node() =:= Node, is_atom(F), is_list(A) ->
+    local_cast(M,F,A);
+cast(Node, M, F, A, infinity) when node() =:= Node, is_atom(F), is_list(A) ->
     local_cast(M,F,A);
 cast(Node, M, F, A, SendTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(A),
                                  SendTO =:= undefined orelse is_integer(SendTO) orelse SendTO =:= infinity ->
@@ -136,8 +138,9 @@ safe_cast(Node, M, F, A) when is_atom(Node), is_atom(M), is_atom(F), is_list(A) 
 %% Safe server cast with custom send timeout value
 %% This is the function that all of the above casts call
 %% Target is itself
-safe_cast(Node, M, F, A, SendTO) when node =:= Node, is_atom(F), is_list(A),
-                                 SendTO =:= undefined orelse is_integer(SendTO) orelse SendTO =:= infinity ->
+safe_cast(Node, M, F, A, undefined) when node() =:= Node, is_atom(F), is_list(A) ->
+    local_cast(M,F,A);
+safe_cast(Node, M, F, A, infinity) when node() =:= Node, is_atom(F), is_list(A) ->
     local_cast(M,F,A);
 %% Target is a non local node
 safe_cast(Node, M, F, A, SendTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(A),

--- a/test/gen_rpc/gen_rpc_test_helper.erl
+++ b/test/gen_rpc/gen_rpc_test_helper.erl
@@ -1,0 +1,19 @@
+%%% -*-mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
+%%% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+%%%
+%%% Copyright 2015 Panagiotis Papadomitsos. All Rights Reserved.
+%%%
+-module(gen_rpc_test_helper).
+-author("Panagiotis Papadomitsos <pj@ezgr.net>").
+
+%%% CT Macros
+-include_lib("test/gen_rpc/include/ct.hrl").
+
+-export([start_target/1]).
+
+%% Start target test erlang node
+start_target(Node)->
+    %% Stop if any node and start from a clean node  
+    net_kernel:stop(), 
+    net_kernel:start([Node, longnames]). 
+

--- a/test/gen_rpc/gen_rpc_test_helper.erl
+++ b/test/gen_rpc/gen_rpc_test_helper.erl
@@ -13,7 +13,15 @@
 
 %% Start target test erlang node
 start_target(Node)->
-    %% Stop if any node and start from a clean node  
-    net_kernel:stop(), 
-    net_kernel:start([Node, longnames]). 
+    %% Try to spin up net_kernel
+    case net_kernel:start([Node, longnames]) of
+        {ok, _} ->
+            {ok, {Node, started}};
+        {error,{already_started, _Pid}} ->
+            {ok, {Node, already_started}};
+        {error, Reason} ->
+            ok = ct:pal("function=start_target event=fail_start_target Reason=\"~p\"", [Reason]),
+            {error, Reason}
+    end
+    .
 

--- a/test/gen_rpc/local_functional_SUITE.erl
+++ b/test/gen_rpc/local_functional_SUITE.erl
@@ -37,7 +37,8 @@
         safe_cast_inexistent_node/1,
         client_inactivity_timeout/1,
         server_inactivity_timeout/1,
-        remote_node_call/1]).
+        remote_node_call/1,
+        remote_node_call_lamda/1]).
 
 %%% Auxiliary functions for test cases
 -export([interleaved_call_proc/3, interleaved_call_executor/1]).
@@ -224,6 +225,11 @@ server_inactivity_timeout(_Config) ->
 remote_node_call(_Config) ->
     ok = ct:pal("Testing [remote_node_call]"),
     {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp).
+
+remote_node_call_lamda(_Config) ->
+    ok = ct:pal("Testing [remote_node_call_lamda]"),
+    {_,"\"call_anonymous_function\""} = gen_rpc:call(?SLAVE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
+                                                     ["call_anonymous_function"]]).
 
 %%% ===================================================
 %%% Auxiliary functions for test cases

--- a/test/gen_rpc/local_functional_SUITE.erl
+++ b/test/gen_rpc/local_functional_SUITE.erl
@@ -4,7 +4,7 @@
 %%% Copyright 2015 Panagiotis Papadomitsos. All Rights Reserved.
 %%%
 
--module(functional_SUITE).
+-module(local_functional_SUITE).
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% CT Macros
@@ -60,7 +60,7 @@ all() ->
 
 init_per_suite(Config) ->
     %% Starting Distributed Erlang on local node
-    {ok, _Pid} = net_kernel:start([?NODE, longnames]),
+    {ok, _Pid} = gen_rpc_test_helper:start_target(?NODE),
     %% Setup application logging
     ?set_application_environment(),
     %% Starting the application locally
@@ -121,12 +121,13 @@ call_anonymous_function(_Config) ->
 
 call_anonymous_undef(_Config) ->
     ok = ct:pal("Testing [call_anonymous_undef]"),
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
-    ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
+    ok = ct:pal("Testing [call_anonymous_undef] Assumping stackstack depth is 5"),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_,_,_,_,_]}}}  = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+   ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [call_mfa_undef]"),
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, os, timestamp_undef),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_,_,_,_,_]}}} = gen_rpc:call(?NODE, os, timestamp_undef),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_exit(_Config) ->
@@ -272,3 +273,4 @@ start_slave() ->
     %% Start the application remotely
     {ok, _SlaveApps} = rpc:call(?SLAVE, application, ensure_all_started, [gen_rpc]),
     ok.
+

--- a/test/gen_rpc/local_functional_SUITE.erl
+++ b/test/gen_rpc/local_functional_SUITE.erl
@@ -37,8 +37,7 @@
         safe_cast_inexistent_node/1,
         client_inactivity_timeout/1,
         server_inactivity_timeout/1,
-        remote_node_call/1,
-        remote_node_call_lamda/1]).
+        remote_node_call/1]).
 
 %%% Auxiliary functions for test cases
 -export([interleaved_call_proc/3, interleaved_call_executor/1]).
@@ -225,11 +224,6 @@ server_inactivity_timeout(_Config) ->
 remote_node_call(_Config) ->
     ok = ct:pal("Testing [remote_node_call]"),
     {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp).
-
-remote_node_call_lamda(_Config) ->
-    ok = ct:pal("Testing [remote_node_call_lamda]"),
-    {_,"\"call_anonymous_function\""} = gen_rpc:call(?SLAVE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
-                                                     ["call_anonymous_function"]]).
 
 %%% ===================================================
 %%% Auxiliary functions for test cases

--- a/test/gen_rpc/remote_functional_SUITE.erl
+++ b/test/gen_rpc/remote_functional_SUITE.erl
@@ -16,8 +16,8 @@
 %%% Testing functions
 -export([supervisor_black_box/1,
         call/1,
-        call_anonymous_function/1,
-        call_anonymous_undef/1,
+ %       call_anonymous_function/1,
+ %       call_anonymous_undef/1,
         call_mfa_undef/1,
         call_mfa_exit/1,
         call_mfa_throw/1,
@@ -71,10 +71,12 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(client_inactivity_timeout, Config) ->
+    ok = start_slave(),
     ok = ?restart_application(),
     ok = application:set_env(?APP, client_inactivity_timeout, 500),
     Config;
 init_per_testcase(server_inactivity_timeout, Config) ->
+    ok = start_slave(),
     ok = ?restart_application(),
     ok = application:set_env(?APP, server_inactivity_timeout, 500),
     Config;
@@ -83,9 +85,11 @@ init_per_testcase(_OtherTest, Config) ->
     Config.
 
 end_per_testcase(client_inactivity_timeout, Config) ->
+    ok = slave:stop(?SLAVE),
     ok = ?restart_application(),
     Config;
 end_per_testcase(server_inactivity_timeout, Config) ->
+    ok = slave:stop(?SLAVE),
     ok = ?restart_application(),
     Config;
 
@@ -110,15 +114,14 @@ call(_Config) ->
     ok = ct:pal("Testing [call]"),
     {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp).
 
-call_anonymous_function(_Config) ->
-    ok = ct:pal("Testing [call_anonymous_function]"),
-    {_,"\"call_anonymous_function\""} = gen_rpc:call(?SLAVE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
-                                                     ["call_anonymous_function"]]).
-
-call_anonymous_undef(_Config) ->
-    ok = ct:pal("Testing [call_anonymous_undef]"),
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?SLAVE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
-    ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
+%call_anonymous_function(_Config) ->
+%    ok = ct:pal("Testing [call_anonymous_function] Lamda on rpc. Usupported."),
+%    {_,"\"call_anonymous_function\""} = gen_rpc:call(?SLAVE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
+%                                                     ["call_anonymous_function"]]).
+%call_anonymous_undef(_Config) ->
+%    ok = ct:pal("Testing [call_anonymous_undef] Lamda on rpc. Unsupported."),
+%    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?SLAVE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+%    ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [call_mfa_undef]"),

--- a/test/gen_rpc/remote_functional_SUITE.erl
+++ b/test/gen_rpc/remote_functional_SUITE.erl
@@ -1,0 +1,266 @@
+%%% -*-mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
+%%% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+%%%
+%%% Copyright 2015 Panagiotis Papadomitsos. All Rights Reserved.
+%%%
+
+-module(remote_functional_SUITE).
+-author("Panagiotis Papadomitsos <pj@ezgr.net>").
+
+%%% CT Macros
+-include_lib("test/gen_rpc/include/ct.hrl").
+
+%%% Common Test callbacks
+-export([all/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
+
+%%% Testing functions
+-export([supervisor_black_box/1,
+        call/1,
+        call_anonymous_function/1,
+        call_anonymous_undef/1,
+        call_mfa_undef/1,
+        call_mfa_exit/1,
+        call_mfa_throw/1,
+        call_with_receive_timeout/1,
+        interleaved_call/1,
+        cast/1,
+        cast_anonymous_function/1,
+        cast_mfa_undef/1,
+        cast_mfa_exit/1,
+        cast_mfa_throw/1,
+        cast_inexistent_node/1,
+        safe_cast/1,
+        safe_cast_anonymous_function/1,
+        safe_cast_mfa_undef/1,
+        safe_cast_mfa_exit/1,
+        safe_cast_mfa_throw/1,
+        safe_cast_inexistent_node/1,
+        client_inactivity_timeout/1,
+        server_inactivity_timeout/1]).
+
+%%% Auxiliary functions for test cases
+-export([interleaved_call_proc/3, interleaved_call_executor/1]).
+
+%%% ===================================================
+%%% CT callback functions
+%%% ===================================================
+all() ->
+    {exports, Functions} = lists:keyfind(exports, 1, ?MODULE:module_info()),
+    [FName || {FName, _} <- lists:filter(
+                               fun ({module_info,_}) -> false;
+                                   ({all,_}) -> false;
+                                   ({init_per_suite,1}) -> false;
+                                   ({end_per_suite,1}) -> false;
+                                   ({interleaved_call_proc,3}) -> false;
+                                   ({interleaved_call_executor,1}) -> false;
+                                   ({_,1}) -> true;
+                                   ({_,_}) -> false
+                               end, Functions)].
+
+init_per_suite(Config) ->
+    %% Starting Distributed Erlang on local node
+    {ok, _Pid} = gen_rpc_test_helper:start_target(?NODE),
+    %% Setup application logging
+    ?set_application_environment(),
+    %% Starting the application locally
+    {ok, _MasterApps} = application:ensure_all_started(?APP),
+    ok = ct:pal("Started [functional] suite with master node [~s]", [node()]),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(client_inactivity_timeout, Config) ->
+    ok = ?restart_application(),
+    ok = application:set_env(?APP, client_inactivity_timeout, 500),
+    Config;
+init_per_testcase(server_inactivity_timeout, Config) ->
+    ok = ?restart_application(),
+    ok = application:set_env(?APP, server_inactivity_timeout, 500),
+    Config;
+init_per_testcase(_OtherTest, Config) ->
+    ok = start_slave(),
+    Config.
+
+end_per_testcase(client_inactivity_timeout, Config) ->
+    ok = ?restart_application(),
+    Config;
+end_per_testcase(server_inactivity_timeout, Config) ->
+    ok = ?restart_application(),
+    Config;
+
+end_per_testcase(_OtherTest, Config) ->
+    ok = slave:stop(?SLAVE),
+    Config.
+
+
+%%% ===================================================
+%%% Test cases
+%%% ===================================================
+%% Test supervisor's status
+supervisor_black_box(_Config) ->
+    ok = ct:pal("Testing [supervisor_black_box]"),
+    true = erlang:is_process_alive(whereis(gen_rpc_server_sup)),
+    true = erlang:is_process_alive(whereis(gen_rpc_acceptor_sup)),
+    true = erlang:is_process_alive(whereis(gen_rpc_client_sup)),
+    ok.
+
+%% Test main functions
+call(_Config) ->
+    ok = ct:pal("Testing [call]"),
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp).
+
+call_anonymous_function(_Config) ->
+    ok = ct:pal("Testing [call_anonymous_function]"),
+    {_,"\"call_anonymous_function\""} = gen_rpc:call(?SLAVE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
+                                                     ["call_anonymous_function"]]).
+
+call_anonymous_undef(_Config) ->
+    ok = ct:pal("Testing [call_anonymous_undef]"),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?SLAVE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+call_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [call_mfa_undef]"),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?SLAVE, os, timestamp_undef),
+    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+call_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [call_mfa_exit]"),
+    {badrpc, {'EXIT', die}} = gen_rpc:call(?SLAVE, erlang, exit, ['die']),
+    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
+
+call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [call_mfa_throw]"),
+    {badrpc, {'EXIT', 'throwXdown'}} = gen_rpc:call(?SLAVE, erlang, throw, ['throwXdown']),
+    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
+
+call_with_receive_timeout(_Config) ->
+    ok = ct:pal("Testing [call_with_receive_timeout]"),
+    {badrpc, timeout} = gen_rpc:call(?SLAVE, timer, sleep, [500], 1),
+    ok = timer:sleep(500).
+
+interleaved_call(_Config) ->
+    ok = ct:pal("Testing [interleaved_call]"),
+    %% Spawn 3 consecutive processes that execute gen_rpc:call
+    %% to the remote node and wait an inversely proportionate time
+    %% for their result (effectively rendering the results out of order)
+    %% in order to test proper data interleaving
+    Pid1 = erlang:spawn(?MODULE, interleaved_call_proc, [self(), 1, infinity]),
+    Pid2 = erlang:spawn(?MODULE, interleaved_call_proc, [self(), 2, 10]),
+    Pid3 = erlang:spawn(?MODULE, interleaved_call_proc, [self(), 3, infinity]),
+    ok = interleaved_call_loop(Pid1, Pid2, Pid3, 0),
+    ok.
+
+cast(_Config) ->
+    ok = ct:pal("Testing [cast]"),
+    true = gen_rpc:cast(?SLAVE, erlang, timestamp).
+
+cast_anonymous_function(_Config) ->
+    ok = ct:pal("Testing [cast_anonymous_function]"),
+    true = gen_rpc:cast(?SLAVE, erlang, apply, [fun() -> os:timestamp() end, []]).
+
+cast_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [cast_mfa_undef]"),
+    true = gen_rpc:cast(?SLAVE, os, timestamp_undef, []).
+
+cast_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [cast_mfa_exit]"),
+    true = gen_rpc:cast(?SLAVE, erlang, apply, [fun() -> exit(die) end, []]).
+
+cast_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [cast_mfa_throw]"),
+    true = gen_rpc:cast(?SLAVE, erlang, throw, ['throwme']).
+
+cast_inexistent_node(_Config) ->
+    ok = ct:pal("Testing [cast_inexistent_node]"),
+    true = gen_rpc:cast(?FAKE_NODE, os, timestamp, []).
+
+safe_cast(_Config) ->
+    ok = ct:pal("Testing [safe_cast]"),
+    true = gen_rpc:safe_cast(?SLAVE, erlang, timestamp).
+
+safe_cast_anonymous_function(_Config) ->
+    ok = ct:pal("Testing [safe_cast_anonymous_function]"),
+    true = gen_rpc:safe_cast(?SLAVE, erlang, apply, [fun() -> os:timestamp() end, []]).
+
+safe_cast_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [safe_cast_mfa_undef]"),
+    true = gen_rpc:safe_cast(?SLAVE, os, timestamp_undef, []).
+
+safe_cast_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [safe_cast_mfa_exit]"),
+    true = gen_rpc:safe_cast(?SLAVE, erlang, apply, [fun() -> exit(die) end, []]).
+
+safe_cast_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [safe_cast_mfa_throw]"),
+    true = gen_rpc:safe_cast(?SLAVE, erlang, throw, ['throwme']).
+
+safe_cast_inexistent_node(_Config) ->
+    ok = ct:pal("Testing [safe_cast_inexistent_node]"),
+    {badrpc, nodedown} = gen_rpc:safe_cast(?FAKE_NODE, os, timestamp, []).
+
+client_inactivity_timeout(_Config) ->
+    ok = ct:pal("Testing [client_inactivity_timeout]"),
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp),
+    ok = timer:sleep(600),
+    %% Lookup the client named process, shouldn't be there
+    undefined = whereis(?SLAVE).
+
+server_inactivity_timeout(_Config) ->
+    ok = ct:pal("Testing [server_inactivity_timeout]"),
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp),
+    ok = timer:sleep(600),
+    %% Lookup the client named process, shouldn't be there
+    [] = supervisor:which_children(gen_rpc_acceptor_sup),
+    %% The server supervisor should have no children
+    [] = supervisor:which_children(gen_rpc_server_sup).
+
+%%% ===================================================
+%%% Auxiliary functions for test cases
+%%% ===================================================
+%% Loop in order to receive all messages from all workers
+interleaved_call_loop(Pid1, Pid2, Pid3, Num) when Num < 3 ->
+    receive
+        {reply, Pid1, 1, 1} ->
+            ct:pal("Received proper reply from Worker 1"),
+            interleaved_call_loop(Pid1, Pid2, Pid3, Num+1);
+        {reply, Pid2, 2, {badrpc, timeout}} ->
+            ct:pal("Received proper reply from Worker 2"),
+            interleaved_call_loop(Pid1, Pid2, Pid3, Num+1);
+        {reply, Pid3, 3, 3} ->
+            ct:pal("Received proper reply from Worker 3"),
+            interleaved_call_loop(Pid1, Pid2, Pid3, Num+1);
+        _Else ->
+            ct:pal("Received out of order reply"),
+            fail
+    end;
+interleaved_call_loop(_, _, _, 3) ->
+    ok.
+
+%% This function will become a spawned process that performs the RPC
+%% call and then returns the value of the RPC call
+%% We spawn it in order to achieve parallelism and test out-of-order
+%% execution of multiple RPC calls
+interleaved_call_proc(Caller, Num, Timeout) ->
+    Result = gen_rpc:call(?SLAVE, ?MODULE, interleaved_call_executor, [Num], Timeout),
+    Caller ! {reply, self(), Num, Result},
+    ok.
+
+%% This is the function that gets executed in the "remote"
+%% node, sleeping 3 minus $Num seconds and returning the number
+%% effectively returning a number thats inversely proportional
+%% to the number of seconds the worker slept
+interleaved_call_executor(Num) when is_integer(Num) ->
+    %% Sleep for 3 - Num
+    ok = timer:sleep((3 - Num) * 1000),
+    %% Then return the number
+    Num.
+
+start_slave() ->
+    %% Starting a slave node with Distributed Erlang
+    {ok, _Slave} = slave:start(?SLAVE_IP, ?SLAVE_NAME, "+K true"),
+    ok = rpc:call(?SLAVE, code, add_pathsz, [code:get_path()]),
+    %% Start the application remotely
+    {ok, _SlaveApps} = rpc:call(?SLAVE, application, ensure_all_started, [gen_rpc]),
+    ok.


### PR DESCRIPTION
Note. 
This is work on top of PR18, as I am unsure if optimization is required. Who intentionally like to RPC himself? If decided to ignore that case, I am happy to throw it away.

* If target node is itself  node(). The call/cast/safe_cast can just be called locally; by pass the rest.
* split the test into local_ and remote_.  Original test is calling using self node for most tests.Also error pattern return from a local node is based on the stacktrace depth set on node. But from a remote node it is less (rpc looks like do the same).
* a test helper

Note: 
There are differences when a anonymous call is sent (it looks like rpc got the same thing).
e.g. gen_rpc:call(TargetNode , erlang, apply, [fun() -> os:timestamp() end], [])
* If target and sender are the same node, it is ok in both shell and script or else crash
* If target and sender are different node, it is ok in shell if they are of the same binary or else crash

