### PR TITLE
Pinfo - rebased to owner's develop branch

### DIFF
--- a/src/gen_rpc.erl
+++ b/src/gen_rpc.erl
@@ -15,6 +15,8 @@
         cast/3,
         cast/4,
         cast/5,
+        pinfo/1,
+        pinfo/2,
         safe_cast/3,
         safe_cast/4,
         safe_cast/5]).
@@ -51,6 +53,18 @@ cast(Node, M, F, A) ->
 -spec cast(Node::node(), M::module(), F::atom()|function(), A::list(), SendTO::timeout()) -> 'true'.
 cast(Node, M, F, A, SendTO) ->
     gen_rpc_client:cast(Node, M, F, A, SendTO).
+
+%% @doc Location transparent version of the BIF process_info/1.
+%%      
+-spec pinfo(Pid::pid()) -> [{Item::atom(), Info::term()}] | undefined.
+ pinfo(Pid) ->
+    call(node(Pid), erlang, process_info, [Pid]).
+
+%% @doc Location transparent version of the BIF process_info/2.
+%% 
+-spec pinfo(Pid::pid(), Iterm::atom()) -> {Item::atom(), Info::term()} | undefined | [].
+ pinfo(Pid, Item) ->
+    call(node(Pid), erlang, process_info, [Pid, Item]).    
 
 -spec safe_cast(Node::node(), M::module(), F::atom()|function()) -> 'true' | {'badrpc', term()} | {'badtcp' | term()}.
 safe_cast(Node, M, F) ->

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -28,6 +28,8 @@
 %%% FSM functions
 -export([call/3, call/4, call/5, call/6, cast/3, cast/4, cast/5, safe_cast/3, safe_cast/4, safe_cast/5]).
 
+-export([pinfo/1, pinfo/2]).
+
 %%% Behaviour callbacks
 -export([init/1, handle_call/3, handle_cast/2,
         handle_info/2, terminate/2, code_change/3]).
@@ -116,6 +118,18 @@ cast(Node, M, F, A, SendTO) when is_atom(Node), is_atom(M), is_atom(F), is_list(
             ok = gen_server:cast(Pid, {{cast,M,F,A},SendTO}),
             true
     end.
+
+%% @doc Location transparent version of the BIF process_info/2.
+%% P
+-spec pinfo(Pid::pid()) -> [{Item::atom(), Info::term()}] | undefined.
+pinfo(Pid) when is_pid(Pid) ->
+    call(node(Pid), erlang, process_info, [Pid]).
+
+%% @doc Location transparent version of the BIF process_info/2.
+%% 
+-spec pinfo(Pid::pid(), Iterm::atom()) -> {Item::atom(), Info::term()} | undefined | [].
+pinfo(Pid, Item) when is_pid(Pid), is_atom(Item) ->
+    call(node(Pid), erlang, process_info, [Pid, Item]).    
 
 %% Safe server cast with no args and default timeout values
 safe_cast(Node, M, F) when is_atom(Node), is_atom(M), is_atom(F) ->

--- a/test/gen_rpc/dummy.erl
+++ b/test/gen_rpc/dummy.erl
@@ -1,0 +1,27 @@
+%%% -*-mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
+%%% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+%%%
+%%% Copyright 2015 Panagiotis Papadomitsos. All Rights Reserved.
+%%%
+
+-module(dummy).
+-author("Panagiotis Papadomitsos <pj@ezgr.net>").
+
+%%% Common Test callbacks
+-export([spawn_long_running/1,
+         spawn_short_running/0,
+         spawn_named_process/1
+]).
+
+spawn_long_running(TimeSpan) -> 
+    spawn(fun() -> timer:sleep(TimeSpan) end).
+
+spawn_short_running() -> 
+    spawn(fun() -> exit(normal) end).
+
+spawn_named_process(TimeSpan) ->
+    Pid = spawn(fun () -> timer:sleep(TimeSpan) end),
+    Name = atom_to_list(node()) ++ "wawawawa",
+    ProcName = list_to_atom(Name),
+    true = register(ProcName, Pid),
+    {Pid, ProcName}.

--- a/test/gen_rpc/local_functional_SUITE.erl
+++ b/test/gen_rpc/local_functional_SUITE.erl
@@ -29,6 +29,9 @@
         cast_mfa_exit/1,
         cast_mfa_throw/1,
         cast_inexistent_node/1,
+        pinfo_alive_process/1,
+        pinfo_dead_process/1,
+        pinfo_item/1,
         safe_cast/1,
         safe_cast_anonymous_function/1,
         safe_cast_mfa_undef/1,
@@ -182,6 +185,27 @@ cast_mfa_throw(_Config) ->
 cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [cast_inexistent_node]"),
     true = gen_rpc:cast(?FAKE_NODE, os, timestamp, [], 1000).
+
+pinfo_alive_process(_Config) ->
+    ok = ct:pal("Testing [pinfo]"),
+    Pid = gen_rpc:call(?NODE, erlang, spawn, [fun() -> timer:sleep(100000) end]),
+    % If this process is alive when pinfo it, we should get non-empty list
+    true = erlang:is_process_alive(Pid),
+    [] =/= gen_rpc:pinfo(Pid).
+
+pinfo_dead_process(_Config) ->
+    ok = ct:pal("Testing [pinfo]"),
+    Pid = gen_rpc:call(?NODE, erlang, spawn, [fun() -> exit(normal) end]),
+    % If this process is dead when pinfo it, we should get undefined.
+    false = gen_rpc:call(?NODE, erlang, is_process_alive, [Pid]),
+    'undefined' = gen_rpc:pinfo(Pid).
+
+pinfo_item(_Config) ->
+    ok = ct:pal("Testing [pinfo_item]"),
+    Pid = gen_rpc:call(?NODE, erlang, spawn, [fun() -> timer:sleep(100000) end]),
+    % If this process is alive when pinfo it, we should get non-empty list
+    true = gen_rpc:call(?NODE, erlang, is_process_alive, [Pid]),
+    [{status,waiting}] = gen_rpc:pinfo(Pid, [status]).
 
 safe_cast(_Config) ->
     ok = ct:pal("Testing [safe_cast]"),

--- a/test/gen_rpc/remote_functional_SUITE.erl
+++ b/test/gen_rpc/remote_functional_SUITE.erl
@@ -27,6 +27,9 @@
         cast_mfa_exit/1,
         cast_mfa_throw/1,
         cast_inexistent_node/1,
+        pinfo_alive_process/1,
+        pinfo_dead_process/1,
+        pinfo_item/1,
         safe_cast/1,
         safe_cast_anonymous_function/1,
         safe_cast_mfa_undef/1,
@@ -167,6 +170,27 @@ cast_mfa_throw(_Config) ->
 cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [cast_inexistent_node]"),
     true = gen_rpc:cast(?FAKE_NODE, os, timestamp, [], 1000).
+
+pinfo_alive_process(_Config) ->
+    ok = ct:pal("Testing [pinfo]"),
+    Pid = gen_rpc:call(?SLAVE, dummy, spawn_long_running, [100000]),
+    % If this process is alive when pinfo it, we should get non-empty list
+    true = gen_rpc:call(?SLAVE, erlang, is_process_alive, [Pid]),
+    [] =/= gen_rpc:pinfo(Pid).
+
+pinfo_dead_process(_Config) ->
+    ok = ct:pal("Testing [pinfo]"),
+    Pid = gen_rpc:call(?SLAVE, dummy, spawn_short_running, []),
+    % If this process is dead when pinfo it, we should get undefined.
+    false = gen_rpc:call(?SLAVE, erlang, is_process_alive, [Pid]),
+    'undefined' = gen_rpc:pinfo(Pid).
+
+pinfo_item(_Config) ->
+    ok = ct:pal("Testing [pinfo_item]"),
+    Pid = gen_rpc:call(?SLAVE, erlang, spawn, [fun() -> timer:sleep(100000) end]),
+    % If this process is alive when pinfo it, we should get non-empty list
+    true = gen_rpc:call(?SLAVE, erlang, is_process_alive, [Pid]),
+    [{status,waiting}] = gen_rpc:pinfo(Pid, [status]).
 
 safe_cast(_Config) ->
     ok = ct:pal("Testing [safe_cast]"),


### PR DESCRIPTION
* 1st draft implementation of pinfo/1 & 2
* basically delegate to gen_rpc:call for erlang process_info (notice rpc uses block_callfor pinfo/2 but not implemented yet)
*  **tests**: 
- call a longer running process so that Pid is still alive when initiate gen_rpc:pinfo
- call a process tht immediate exit
- call a living process for process status 
Same on remote node.