### PR TITLE
Block_call (Clean up version of PR pull/26.)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ spec: dialyzer
 	@$(TYPER) --annotate-inc-files -I ./include --plt $(PLT_FILE) -r src/
 
 dist: $(REBAR) test
-	@REBAR_PROFILE=test $(REBAR) do dialyzer, xref
+	@REBAR_PROFILE=dev $(REBAR) do dialyzer, xref
 
 coveralls: $(COVERDATA)
 	@REBAR_PROFILE=test $(REBAR) do coveralls send || true

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ spec: dialyzer
 	@$(TYPER) --annotate-inc-files -I ./include --plt $(PLT_FILE) -r src/
 
 dist: $(REBAR) test
-	@REBAR_PROFILE=dev $(REBAR) do dialyzer, xref
+	@REBAR_PROFILE=test $(REBAR) do dialyzer, xref
 
 # =============================================================================
 # Run targets

--- a/src/gen_rpc.erl
+++ b/src/gen_rpc.erl
@@ -8,7 +8,10 @@
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% Library interface
--export([call/3,
+-export([block_call/4,
+        block_call/5,
+        block_call/6,
+        call/3,
         call/4,
         call/5,
         call/6,
@@ -32,6 +35,18 @@
 %%% ===================================================
 %% All functions are GUARD-ed in the sender module, no
 %% need for the overhead here
+-spec block_call(Node::node(), M::module(), F::atom()|function(),  RecvTO::timeout()) -> term() | {badrpc, term()}.
+block_call(Node, M, F, RecvTO) ->
+    gen_rpc_client:block_call(Node, M, F, RecvTO).
+
+-spec block_call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout()) -> term() | {badrpc, term()}.
+block_call(Node, M, F, A, RecvTO) ->
+    gen_rpc_client:block_call(Node, M, F, A, RecvTO).
+
+-spec block_call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout(), SendTO::timeout()) -> term() | {badrpc, term()}.
+block_call(Node, M, F, A, RecvTO, SendTO) ->
+    gen_rpc_client:block_call(Node, M, F, A, RecvTO, SendTO).
+
 -spec call(Node::node(), M::module(), F::atom()|function()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
 call(Node, M, F) ->
     gen_rpc_client:call(Node, M, F).

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -89,9 +89,9 @@ waiting_for_data({data, Data}, #state{socket=Socket,client_node=Node} = State) -
     %% the data
     try erlang:binary_to_term(Data) of
         {Node, ClientPid, Ref, {block_call, M, F, A}} ->
-            WorkerPid = erlang:spawn(?MODULE, call_worker, [self(), ClientPid, Ref, M, F, A]),
-            ok = lager:debug("function=waiting_for_data event=block_call_received socket=\"~p\" node=\"~s\" call_reference=\"~p\" client_pid=\"~p\" worker_pid=\"~p\"",
-                             [Socket, Node, Ref, ClientPid, WorkerPid]),
+            ok = call_worker(self(), ClientPid, Ref, M, F, A),
+            ok = lager:debug("function=waiting_for_data event=block_call_received socket=\"~p\" node=\"~s\" call_reference=\"~p\" client_pid=\"~p\"",
+                             [Socket, Node, Ref, ClientPid]),
             ok = inet:setopts(Socket, [{active, once}]),
             {next_state, waiting_for_data, State, State#state.inactivity_timeout};
         {Node, ClientPid, Ref, {call, M, F, A}} ->

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -512,7 +512,7 @@ normalize_timeout(E) -> E.
 
 normalize_reply({'EXIT', {timeout,_}}) -> {badrpc, timeout};
 normalize_reply({'EXIT', {{nodedown,_},_}}) -> {badrpc, nodedown};
-normalize_reply({'EXIT', X}) -> exit(X);
+normalize_reply({'EXIT', X}) -> {badrpc, X};
 normalize_reply(X) -> X.
 
 %% Transform result for safe_eval_everywhere to look like multicall

--- a/test/ct/local_functional_SUITE.erl
+++ b/test/ct/local_functional_SUITE.erl
@@ -97,13 +97,13 @@ block_call_anonymous_undef(_Config) ->
     ok = ct:pal("Testing [block_call_anonymous_undef]"),
     ok = ct:pal("Testing [block_call_anonymous_undef] Assumping stackstack depth is 5"),
     RevTO = 200,
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}}  = gen_rpc:block_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []], RevTO),
+    {badrpc, {'EXIT',{undef, [{os,timestamp_undef,_,_},_,_,_,_]}}} = gen_rpc:block_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []], RevTO),
    ok = ct:pal("Result [block_call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 block_call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [block_call_mfa_undef]"),
     RevTO = 200,
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:block_call(?NODE, os, timestamp_undef, RevTO),
+    {badrpc, {'EXIT',{undef, [{os,timestamp_undef,_,_},_,_,_,_]}}} = gen_rpc:block_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []], RevTO),
     ok = ct:pal("Result [block_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 block_call_mfa_exit(_Config) ->

--- a/test/ct/local_functional_SUITE.erl
+++ b/test/ct/local_functional_SUITE.erl
@@ -78,6 +78,52 @@ supervisor_black_box(_Config) ->
     ok.
 
 %% Test main functions
+block_call(_Config) ->
+    ok = ct:pal("Testing [block_call]"),
+    RevTO = 200,
+    {_Mega, _Sec, _Micro} = gen_rpc:block_call(?NODE, os, timestamp, RevTO).
+
+block_call_mfa(_Config) ->
+    ok = ct:pal("Testing [block_call_mfa]"),
+    SendTO = RevTO = 200,
+    true = gen_rpc:block_call(?NODE, erlang, is_process_alive, [whereis(gen_rpc_client_sup)], RevTO, SendTO).
+
+block_call_anonymous_function(_Config) ->
+    ok = ct:pal("Testing [block_call_anonymous_function]"),
+    RevTO = 200,
+    {_,"\"block_call_anonymous_function\""} = gen_rpc:block_call(?NODE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,                                                     ["block_call_anonymous_function"]], RevTO).
+
+block_call_anonymous_undef(_Config) ->
+    ok = ct:pal("Testing [block_call_anonymous_undef]"),
+    ok = ct:pal("Testing [block_call_anonymous_undef] Assumping stackstack depth is 5"),
+    RevTO = 200,
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}}  = gen_rpc:block_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []], RevTO),
+   ok = ct:pal("Result [block_call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+block_call_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [block_call_mfa_undef]"),
+    RevTO = 200,
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:block_call(?NODE, os, timestamp_undef, RevTO),
+    ok = ct:pal("Result [block_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+block_call_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [block_call_mfa_exit]"),
+    RevTO = 200,
+    {badrpc, {'EXIT', die}} = gen_rpc:block_call(?NODE, erlang, exit, ['die'], RevTO),
+    ok = ct:pal("Result [block_call_mfa_undef]: signal=EXIT Reason={die}").
+
+block_call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [block_call_mfa_throw]"),
+    RevTO = 200,
+    'throwXdown' = gen_rpc:block_call(?NODE, erlang, throw, ['throwXdown'], RevTO),
+    ok = ct:pal("Result [block_call_mfa_undef]: signal=EXIT Reason={die}").
+
+block_call_with_receive_timeout(_Config) ->
+    ok = ct:pal("Testing [block_call_with_receive_timeout]"),
+    RevTO = 1,
+    {badrpc, timeout} = gen_rpc:block_call(?NODE, timer, sleep, [500], RevTO),
+    ok = timer:sleep(500).
+
 call(_Config) ->
     ok = ct:pal("Testing [call]"),
     {_Mega, _Sec, _Micro} = gen_rpc:call(?NODE, os, timestamp).

--- a/test/ct/remote_functional_SUITE.erl
+++ b/test/ct/remote_functional_SUITE.erl
@@ -67,6 +67,41 @@ end_per_testcase(_OtherTest, Config) ->
 %%% Test cases
 %%% ===================================================
 %% Test main functions
+block_call(_Config) ->
+    ok = ct:pal("Testing [block_call]"),
+    RevTO = 200,
+    {_Mega, _Sec, _Micro} = gen_rpc:block_call(?SLAVE, os, timestamp, RevTO).
+
+block_call_mfa(_Config) ->
+    ok = ct:pal("Testing [block_call_mfa]"),
+    SendTO = RevTO = 200,
+    R = gen_rpc:block_call(?SLAVE, erlang, atom_to_binary, ['jajaja', latin1], RevTO, SendTO),
+    R = <<"jajaja">>.
+
+block_call_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [block_call_mfa_undef]"),
+    RevTO = 200,
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:block_call(?SLAVE, os, timestamp_undef, RevTO),
+    ok = ct:pal("Result [block_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+block_call_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [block_call_mfa_exit]"),
+    RevTO = 200,
+    {badrpc, {'EXIT', die}} = gen_rpc:block_call(?SLAVE, erlang, exit, ['die'], RevTO),
+    ok = ct:pal("Result [block_call_mfa_undef]: signal=EXIT Reason={die}").
+
+block_call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [block_call_mfa_throw]"),
+    RevTO = 200,
+    'throwXdown' = gen_rpc:block_call(?SLAVE, erlang, throw, ['throwXdown'], RevTO),
+    ok = ct:pal("Result [block_call_mfa_undef]: signal=EXIT Reason={die}").
+
+block_call_with_receive_timeout(_Config) ->
+    ok = ct:pal("Testing [block_call_with_receive_timeout]"),
+    RevTO = 1,
+    {badrpc, timeout} = gen_rpc:block_call(?SLAVE, timer, sleep, [500], RevTO),
+    ok = timer:sleep(500).
+
 call(_Config) ->
     ok = ct:pal("Testing [call]"),
     {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp).

--- a/test/ct/remote_functional_SUITE.erl
+++ b/test/ct/remote_functional_SUITE.erl
@@ -81,7 +81,7 @@ block_call_mfa(_Config) ->
 block_call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [block_call_mfa_undef]"),
     RevTO = 200,
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:block_call(?SLAVE, os, timestamp_undef, RevTO),
+    {badrpc, {'EXIT',{undef, [{os,timestamp_undef,_,_},_,_,_,_]}}} = gen_rpc:block_call(?SLAVE, os, timestamp_undef, RevTO),
     ok = ct:pal("Result [block_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 block_call_mfa_exit(_Config) ->


### PR DESCRIPTION
Clean up, squashed version of https://github.com/priestjim/gen_rpc/pull/26
Trial implementation of block_call.
Implementation:
* block_call(Node, M, F, RecvTO)
* block_call(Node, M, F, A, RecvTO
* block_call(Node, M, F, A, RecvTO, SendTO)

Basically the same as Call except for blocking the calling process, and prevent RPC server from handling other requests until current one exits.
* The CallerPid acts as call correlation ID.

Ref: http://www.erlang.org/doc/man/rpc.html


