### PR TITLE
Async call. Cleaned up of PR27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ spec: dialyzer
 	@$(TYPER) --annotate-inc-files -I ./include --plt $(PLT_FILE) -r src/
 
 dist: $(REBAR) test
-	@REBAR_PROFILE=test $(REBAR) do dialyzer, xref
+	@REBAR_PROFILE=dev $(REBAR) do dialyzer, xref
 
 coveralls: $(COVERDATA)
 	@REBAR_PROFILE=test $(REBAR) do coveralls send || true

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ spec: dialyzer
 	@$(TYPER) --annotate-inc-files -I ./include --plt $(PLT_FILE) -r src/
 
 dist: $(REBAR) test
-	@REBAR_PROFILE=dev $(REBAR) do dialyzer, xref
+	@REBAR_PROFILE=test $(REBAR) do dialyzer, xref
 
 # =============================================================================
 # Run targets

--- a/src/gen_rpc.erl
+++ b/src/gen_rpc.erl
@@ -8,7 +8,9 @@
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% Library interface
--export([call/3,
+-export([async_call/3,
+        async_call/4,
+        call/3,
         call/4,
         call/5,
         call/6,
@@ -18,6 +20,10 @@
         eval_everywhere/3,
         eval_everywhere/4,
         eval_everywhere/5,
+        yield/1,
+        yield/2,
+        nb_yield/1,
+        nb_yield/2,
         pinfo/1,
         pinfo/2,
         safe_cast/3,
@@ -32,6 +38,14 @@
 %%% ===================================================
 %% All functions are GUARD-ed in the sender module, no
 %% need for the overhead here
+-spec async_call(Node::node(), M::module(), F::atom()|function()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
+async_call(Node, M, F) ->
+    gen_rpc_client:async_call(Node, M, F).
+
+-spec async_call(Node::node(), M::module(), F::atom()|function(), A::list()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
+async_call(Node, M, F, A) ->
+    gen_rpc_client:async_call(Node, M, F, A).
+
 -spec call(Node::node(), M::module(), F::atom()|function()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
 call(Node, M, F) ->
     gen_rpc_client:call(Node, M, F).
@@ -120,4 +134,20 @@ safe_eval_everywhere(Nodes, M, F, A) ->
 -spec safe_eval_everywhere(Nodes::[node()], M::module(), F::atom()|function(), A::list(), SendTO::timeout()) ->  ['true'  | [node()]].
 safe_eval_everywhere(Nodes, M, F, A, SendTO) ->
     gen_rpc_client:safe_eval_everywhere(Nodes, M, F, A, SendTO).
+
+-spec yield(Key::pid()) -> term() | {badrpc, term()}.
+yield(Key) ->
+    gen_rpc_client:yield(Key).
+
+-spec yield(Key::pid(), RecvTO::timeout()) -> term() | {badrpc, term()}.
+yield(Key, RecvTO) ->
+    gen_rpc_client:yield(Key, RecvTO).
+
+-spec nb_yield(Key::pid()) -> {value, term()} | {badrpc, term()}.
+nb_yield(Key) ->
+    gen_rpc_client:nb_yield(Key).
+
+-spec nb_yield(Key::pid(), Timeout::timeout()) -> {value, term()} | {badrpc, term()}.
+nb_yield(Key, Timeout) ->
+    gen_rpc_client:nb_yield(Key, Timeout).
 

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -221,9 +221,12 @@ nb_yield(Key)->
     nb_yield(Key, 0).
 
 %% Simple server non-blocking yield with key and custom timeout value
-nb_yield(Key, Timeout) when is_pid(Key), is_integer(Timeout) orelse Timeout =:= infinity ->
+nb_yield(Key, Timeout) when is_pid(Key), ?is_timeout(Timeout) ->
     receive 
             {Key, {promise_reply, Reply}} -> {value, Reply};
+            {badtcp, Reason} ->
+                    ok = lager:notice("function=nb_yield event=call_bad_tcp yield_key=\"~p\" reason=\"~p\"", [Key, Reason]),
+                    {value, {badtcp, Reason}};
             UnknownMsg -> 
                     ok = lager:notice("function=nb_yield event=unknown_msg yield_key=\"~p\" message=\"~p\"", [Key, UnknownMsg]),
                     {value, {badrpc, timeout}}

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -212,8 +212,7 @@ yield(Key)->
 
 yield(Key, YieldTO)-> 
     case nb_yield(Key, YieldTO) of
-        {value, R} -> R;
-        {badrpc, Reason} -> {badrpc, Reason}
+        {value, R} -> R
     end.
 
 %% Simple server non-blocking yield with key, default timeout value of 0

--- a/test/ct/local_functional_SUITE.erl
+++ b/test/ct/local_functional_SUITE.erl
@@ -216,6 +216,7 @@ async_call_yield_reentrant(_Config) ->
     {ok, _} = timer:kill_after(5000, Pid),
     NbYieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
     {value, {_,_,_}} = gen_rpc:nb_yield(NbYieldKey0, 100),
+    % Verify not able to reuse Key again. Key is one time use.
     {value, {badrpc, timeout}} = gen_rpc:nb_yield(NbYieldKey0, 10),
     YieldKey = gen_rpc:async_call(?NODE, io_lib, print, [yield_key]),
     "yield_key" = gen_rpc:yield(YieldKey),

--- a/test/ct/local_functional_SUITE.erl
+++ b/test/ct/local_functional_SUITE.erl
@@ -106,7 +106,7 @@ call_mfa_exit(_Config) ->
 call_mfa_throw(_Config) ->
     ok = ct:pal("Testing [call_mfa_throw]"),
     'throwXdown' = gen_rpc:call(?NODE, erlang, throw, ['throwXdown']),
-    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
+    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={throwXdown}").
 
 call_with_receive_timeout(_Config) ->
     ok = ct:pal("Testing [call_with_receive_timeout]"),
@@ -193,6 +193,99 @@ safe_cast_mfa_throw(_Config) ->
 safe_cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [safe_cast_inexistent_node]"),
     {badrpc, nodedown} = gen_rpc:safe_cast(?FAKE_NODE, os, timestamp, [], 1000).
+
+async_call(_Config) ->
+    ok = ct:pal("Testing [async_call]"),
+    YieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
+    NbYieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    {value,{_,_,_}}= gen_rpc:nb_yield(NbYieldKey0, 10),
+    YieldKey = gen_rpc:async_call(?NODE, io_lib, print, [yield_key]),
+    "yield_key" = gen_rpc:yield(YieldKey),
+    NbYieldKey = gen_rpc:async_call(?NODE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
+
+async_call_yield_reentrant(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_reentrant]"),
+    YieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
+    Pid = proc_lib:spawn(fun()->  
+                                {value, {badrpc, timeout}} = gen_rpc:yield(YieldKey0),
+                                ok = ct:pal("yield/1 waits forever. Should never see this.")
+                         end),
+    {ok, _} = timer:kill_after(5000, Pid),
+    NbYieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    {value, {_,_,_}} = gen_rpc:nb_yield(NbYieldKey0, 100),
+    {value, {badrpc, timeout}} = gen_rpc:nb_yield(NbYieldKey0, 10),
+    YieldKey = gen_rpc:async_call(?NODE, io_lib, print, [yield_key]),
+    "yield_key" = gen_rpc:yield(YieldKey),
+    {badrpc, timeout} = gen_rpc:yield(YieldKey, 100),
+    NbYieldKey = gen_rpc:async_call(?NODE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
+
+async_call_anonymous_function(_Config) ->
+    ok = ct:pal("Testing [async_call_anonymous_function]"),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
+                                                     [yield_key_anonymous_func]]),
+    {_, "yield_key_anonymous_func"} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
+                                                     [nb_yield_key_anonymous_func]]),
+    {value, {_, "nb_yield_key_anonymous_func"}} = gen_rpc:nb_yield(NBYieldKey, 10).
+
+async_call_anonymous_undef(_Config) ->
+    ok = ct:pal("Testing [async_call_anonymous_undef]"),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 10),
+    ok = ct:pal("Result [async_call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_undef]"),
+    YieldKey = gen_rpc:async_call(?NODE, os, timestamp_undef),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, os, timestamp_undef),
+    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 20),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_exit]"),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, exit, ['die']),
+    {badrpc, {'EXIT', die}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, exit, ['die']),
+    {value, {badrpc, {'EXIT', die}}} = gen_rpc:nb_yield(NBYieldKey, 10),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_throw]"),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, throw, ['throwXdown']),
+    'throwXdown' = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, throw, ['throwXdown']),
+    {value, 'throwXdown'} = gen_rpc:nb_yield(NBYieldKey, 10),
+    ok = ct:pal("Result [async_call_mfa_undef]: throw Reason={throwXdown}").
+
+async_call_yield_timeout(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_timeout]"),
+    YieldKey = gen_rpc:async_call(?NODE, timer, sleep, [1000]),
+    {badrpc,timeout} = gen_rpc:yield(YieldKey, 5),
+    NBYieldKey = gen_rpc:async_call(?NODE, timer, sleep, [1000]),
+    {value, {badrpc,timeout}} = gen_rpc:nb_yield(NBYieldKey, 5),
+    ok = ct:pal("Result [async_call_yield_timeout]: signal=badrpc Reason={timeout}").
+
+async_call_nb_yield_infinity(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_infinity]"),
+    YieldKey = gen_rpc:async_call(?NODE, timer, sleep, [1000]),
+    ok = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, timer, sleep, [1000]),
+    {value, ok} = gen_rpc:nb_yield(NBYieldKey, infinity),
+    ok = ct:pal("Result [async_call_yield_infinity]: timer_sleep Result={ok}").
+
+async_call_inexistent_node(_Config) ->
+    ok = ct:pal("Testing [async_call_inexistent_node]"),
+    YieldKey1 = gen_rpc:async_call(?FAKE_NODE, os, timestamp, []),
+    {badrpc, nodedown} = gen_rpc:yield(YieldKey1),
+    YieldKey2 = gen_rpc:async_call(?FAKE_NODE, os, timestamp, []),
+    {value, {badrpc, nodedown}} = gen_rpc:nb_yield(YieldKey2, 5000).
 
 client_inactivity_timeout(_Config) ->
     ok = ct:pal("Testing [client_inactivity_timeout]"),

--- a/test/ct/multi_rpc_functional_SUITE.erl
+++ b/test/ct/multi_rpc_functional_SUITE.erl
@@ -55,8 +55,15 @@ eval_everywhere_mfa_no_node(_Config) ->
     true = erlang:is_process_alive(whereis(gen_rpc_acceptor_sup)),
     true = erlang:is_process_alive(whereis(gen_rpc_client_sup)).
 
+%% Eval_everywhere is fire and forget, which means some test cases need to show
+%% something has been executed on target nodes. 
+%% The main technique used in eval_everywhere testing is to setup servers- slaves,
+%% and have the test script to ping the slaves with tagged messages and then wait for 
+%% such and match the tags to verify originality.
+
 %% Ping the target node with tagged msg. Target Node reply back with
 %% tagged msg and its own identity.
+ 
 eval_everywhere_mfa_one_node(_Config) ->
     ok = ct:pal("Testing [eval_everywhere_mfa_one_node]"),
     ConnectedNodes = [?SLAVE1],

--- a/test/ct/remote_functional_SUITE.erl
+++ b/test/ct/remote_functional_SUITE.erl
@@ -193,7 +193,8 @@ async_call_yield_reentrant(_Config) ->
                          end),
     {ok, _} = timer:kill_after(5000, Pid),
     NbYieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
-    {value, {_,_,_}} = gen_rpc:nb_yield(NbYieldKey0, 10),
+    % Verify not able to reuse Key again. Key is one time use.
+    {_,_,_} = gen_rpc:yield(NbYieldKey0, 100),
     {value, {badrpc, timeout}} = gen_rpc:nb_yield(NbYieldKey0, 10),
     YieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [yield_key]),
     "yield_key" = gen_rpc:yield(YieldKey),

--- a/test/ct/remote_functional_SUITE.erl
+++ b/test/ct/remote_functional_SUITE.erl
@@ -172,6 +172,75 @@ safe_cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [safe_cast_inexistent_node]"),
     {badrpc, nodedown} = gen_rpc:safe_cast(?FAKE_NODE, os, timestamp, [], 1000).
 
+async_call(_Config) ->
+    ok = ct:pal("Testing [async_call]"),
+    YieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
+    NbYieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    {value,{_,_,_}}= gen_rpc:nb_yield(NbYieldKey0, 10),
+    YieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [yield_key]),
+    "yield_key" = gen_rpc:yield(YieldKey),
+    NbYieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
+
+async_call_yield_reentrant(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_reentrant]"),
+    YieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
+    Pid = proc_lib:spawn(fun()->
+                                {value, {badrpc, timeout}} = gen_rpc:yield(YieldKey0),
+                                ok = ct:pal("yield/1 waits forever. Should never see this.")
+                         end),
+    {ok, _} = timer:kill_after(5000, Pid),
+    NbYieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    {value, {_,_,_}} = gen_rpc:nb_yield(NbYieldKey0, 10),
+    {value, {badrpc, timeout}} = gen_rpc:nb_yield(NbYieldKey0, 10),
+    YieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [yield_key]),
+    "yield_key" = gen_rpc:yield(YieldKey),
+    {badrpc, timeout} = gen_rpc:yield(YieldKey, 100),
+    NbYieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
+
+async_call_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_undef]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, os, timestamp_undef),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, os, timestamp_undef),
+    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 20),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_exit]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, erlang, exit, ['die']),
+    {badrpc, {'EXIT', die}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, erlang, exit, ['die']),
+    {value, {badrpc, {'EXIT', die}}} = gen_rpc:nb_yield(NBYieldKey, 10),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_throw]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, erlang, throw, ['throwXdown']),
+    'throwXdown' = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, erlang, throw, ['throwXdown']),
+    {value, 'throwXdown'} = gen_rpc:nb_yield(NBYieldKey, 10),
+    ok = ct:pal("Result [async_call_mfa_undef]: throw Reason={throwXdown}").
+
+async_call_yield_timeout(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_timeout]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    {badrpc,timeout} = gen_rpc:yield(YieldKey, 5),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    {value, {badrpc,timeout}} = gen_rpc:nb_yield(NBYieldKey, 5),
+    ok = ct:pal("Result [async_call_yield_timeout]: signal=badrpc Reason={timeout}").
+
+async_call_nb_yield_infinity(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_infinity]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    ok = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    {value, ok} = gen_rpc:nb_yield(NBYieldKey, infinity),
+    ok = ct:pal("Result [async_call_yield_infinity]: timer_sleep Result={ok}").
+
 client_inactivity_timeout(_Config) ->
     ok = ct:pal("Testing [client_inactivity_timeout]"),
     {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp),


### PR DESCRIPTION
Draft implementation of async_call/3, async_call/4, yield/1, nb_yield/1, nb_yield/2.
* added tests on local and remote node executions.
* new yield_timeout in app.src to set the default timeout for yield because:
- * the RPC implementation defaults to infinity which on careless use will hang
- * so instead use an explicit setting in config that defaults to infinity to mimic the PRC behavior but makes this timeout less hidden

NB:
- same caveat of anonymous function execution on remote node
- nb_yield/1 per rpc doc has implicit default timeout of 0. I don't quite know what the use of this API.  "flushing?". If so,this is such a bad name.

Clean up of https://github.com/priestjim/gen_rpc/pull/27
