### PR TITLE
Multicall_clean Clean up version of PR30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ spec: dialyzer
 	@$(TYPER) --annotate-inc-files -I ./include --plt $(PLT_FILE) -r src/
 
 dist: $(REBAR) test
-	@REBAR_PROFILE=test $(REBAR) do dialyzer, xref
+	@REBAR_PROFILE=dev $(REBAR) do dialyzer, xref
 
 coveralls: $(COVERDATA)
 	@REBAR_PROFILE=test $(REBAR) do coveralls send || true

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ spec: dialyzer
 	@$(TYPER) --annotate-inc-files -I ./include --plt $(PLT_FILE) -r src/
 
 dist: $(REBAR) test
-	@REBAR_PROFILE=dev $(REBAR) do dialyzer, xref
+	@REBAR_PROFILE=test $(REBAR) do dialyzer, xref
 
 # =============================================================================
 # Run targets

--- a/src/gen_rpc.erl
+++ b/src/gen_rpc.erl
@@ -8,16 +8,24 @@
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% Library interface
--export([call/3,
+-export([async_call/3,
+        async_call/4,
+        call/3,
         call/4,
         call/5,
         call/6,
+        multicall/5,
+        multicall/6,
         cast/3,
         cast/4,
         cast/5,
         eval_everywhere/3,
         eval_everywhere/4,
         eval_everywhere/5,
+        yield/1,
+        yield/2,
+        nb_yield/1,
+        nb_yield/2,
         pinfo/1,
         pinfo/2,
         safe_cast/3,
@@ -32,6 +40,14 @@
 %%% ===================================================
 %% All functions are GUARD-ed in the sender module, no
 %% need for the overhead here
+-spec async_call(Node::node(), M::module(), F::atom()|function()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
+async_call(Node, M, F) ->
+    gen_rpc_client:async_call(Node, M, F).
+
+-spec async_call(Node::node(), M::module(), F::atom()|function(), A::list()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
+async_call(Node, M, F, A) ->
+    gen_rpc_client:async_call(Node, M, F, A).
+
 -spec call(Node::node(), M::module(), F::atom()|function()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
 call(Node, M, F) ->
     gen_rpc_client:call(Node, M, F).
@@ -43,6 +59,14 @@ call(Node, M, F, A) ->
 -spec call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
 call(Node, M, F, A, RecvTO) ->
     gen_rpc_client:call(Node, M, F, A, RecvTO).
+
+-spec multicall(Nodes::[node()], M::module(), F::atom()|function(), RecvTO::timeout(), SendTO::timeout()) -> term() | {badrpc, term()}.
+multicall(Nodes, M, F, RecvTO, SendTO) ->
+    gen_rpc_client:multicall(Nodes, M, F, RecvTO, SendTO).
+
+-spec multicall(Nodes::[node()], M::module(), F::atom()|function(), A::list(), RecvTO::timeout(), SendTO::timeout()) -> term() | {badrpc, term()}.
+multicall(Nodes, M, F, A, RecvTO, SendTO) ->
+    gen_rpc_client:multicall(Nodes, M, F, A, RecvTO, SendTO).
 
 -spec call(Node::node(), M::module(), F::atom()|function(), A::list(), RecvTO::timeout(), SendTO::timeout()) -> term() | {'badrpc', term()} | {'badtcp' | term()}.
 call(Node, M, F, A, RecvTO, SendTO) ->
@@ -120,4 +144,20 @@ safe_eval_everywhere(Nodes, M, F, A) ->
 -spec safe_eval_everywhere(Nodes::[node()], M::module(), F::atom()|function(), A::list(), SendTO::timeout()) ->  ['true'  | [node()]].
 safe_eval_everywhere(Nodes, M, F, A, SendTO) ->
     gen_rpc_client:safe_eval_everywhere(Nodes, M, F, A, SendTO).
+
+-spec yield(Key::pid()) -> term() | {badrpc, term()}.
+yield(Key) ->
+    gen_rpc_client:yield(Key).
+
+-spec yield(Key::pid(), RecvTO::timeout()) -> term() | {badrpc, term()}.
+yield(Key, RecvTO) ->
+    gen_rpc_client:yield(Key, RecvTO).
+
+-spec nb_yield(Key::pid()) -> {value, term()} | {badrpc, term()}.
+nb_yield(Key) ->
+    gen_rpc_client:nb_yield(Key).
+
+-spec nb_yield(Key::pid(), Timeout::timeout()) -> {value, term()} | {badrpc, term()}.
+nb_yield(Key, Timeout) ->
+    gen_rpc_client:nb_yield(Key, Timeout).
 

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -30,8 +30,12 @@
 %%% FSM functions
 -export([call/3, call/4, call/5, call/6, cast/3, cast/4, cast/5, safe_cast/3, safe_cast/4, safe_cast/5]).
 
+-export([multicall/5, multicall/6]).
+
 -export([eval_everywhere/3, eval_everywhere/4, eval_everywhere/5,
          safe_eval_everywhere/3, safe_eval_everywhere/4, safe_eval_everywhere/5]).
+
+-export([async_call/3, async_call/4, async_call/6, yield/1, yield/2, nb_yield/1, nb_yield/2]).
 
 -export([pinfo/1, pinfo/2]).
 
@@ -41,6 +45,7 @@
 
 %%% Process exports
 -export([call_worker/3]).
+-export([yield_results/1]).
 
 %%% ===================================================
 %%% Supervisor functions
@@ -56,6 +61,28 @@ stop(Node) when is_atom(Node) ->
 %%% ===================================================
 %%% Server functions
 %%% ===================================================
+%% Simple server async_call with no args
+async_call(Node, M, F)->
+    async_call(Node, M, F, []).
+
+%% Simple server async_call with args
+async_call(Node, M, F, A) when is_atom(Node), is_atom(M), is_atom(F), is_list(A) ->
+    ReplyTo = self(),
+    ok = lager:info("function=async_call event=spawning_call_process server_node=\"~s\" action=spawning_call_process", [Node]),
+    spawn(fun()-> 
+              Reply = call(Node, M, F, A, undefined, undefined),
+              ReplyTo ! {self(), {promise_reply, Reply}}
+          end).    
+
+%% Simple server async_call with args
+async_call(Node, M, F, A, RecvTO, SendTO) ->
+    ReplyTo = self(),
+    ok = lager:info("function=async_call event=spawning_call_process server_node=\"~s\" action=spawning_call_process", [Node]),
+    spawn(fun()-> 
+              Reply = call(Node, M, F, A, RecvTO, SendTO),
+              ReplyTo ! {self(), {promise_reply, Reply}}
+          end).
+
 %% Simple server call with no args and default timeout values
 call(Node, M, F) ->
     call(Node, M, F, [], undefined, undefined).
@@ -89,6 +116,21 @@ call(Node, M, F, A, RecvTO, SendTO) when is_atom(Node), is_atom(M), is_atom(F), 
             ok = lager:debug("function=call event=client_process_found pid=\"~p\" server_node=\"~s\"", [Pid, Node]),
             gen_server:call(Pid, {{call,M,F,A},RecvTO,SendTO}, infinity)
     end.
+
+multicall(Nodes, M, F, RecvTO, SendTO) ->
+    multicall(Nodes, M, F, [], RecvTO, SendTO).
+
+multicall([], _M, _F, _A, _RecvTO, _SendTO) -> [[],[]];
+%% multicall with args and custom send timeout values
+multicall(Nodes, M, F, A, RecvTO, SendTO) when is_list(Nodes), is_atom(M), is_atom(F), is_list(A),
+                                         RecvTO =:= undefined orelse ?is_timeout(RecvTO),
+                                         SendTO =:= undefined orelse ?is_timeout(SendTO) ->
+    % Can't use gen_server:multicall which requires all peer process having the same name
+    NodeKeyList  = lists:map(fun(Node)->
+                                Key = async_call(Node, M, F, A, RecvTO, SendTO),
+                                {Node, Key}
+                             end, Nodes),
+    yield_results(NodeKeyList).
 
 %% Simple server cast with no args and default timeout values
 cast(Node, M, F) ->
@@ -142,6 +184,7 @@ eval_everywhere(Nodes, M, F, A, SendTO) when is_list(Nodes), is_atom(M), is_atom
 pinfo(Pid) when is_pid(Pid) ->
     call(node(Pid), erlang, process_info, [Pid]).
 
+%% @doc Location transparent version of the BIF process_info/2.
 -spec pinfo(Pid::pid(), Iterm::atom()) -> {Item::atom(), Info::term()} | undefined | [].
 pinfo(Pid, Item) when is_pid(Pid), is_atom(Item) ->
     call(node(Pid), erlang, process_info, [Pid, Item]).
@@ -191,6 +234,34 @@ safe_eval_everywhere(Nodes, M, F, A, SendTO) when is_list(Nodes), is_atom(M), is
     Ret = [{Node, safe_cast(Node, M, F, A, SendTO)} || Node <- Nodes],
     parse_safe_eval_everywhere_result(Ret, Nodes).
 
+%% @doc Simple server yield with key. Delegate to nb_yield. Default timeout form configuration.
+yield(Key)-> 
+    yield(Key, infinity).
+
+yield(Key, YieldTO)-> 
+    case nb_yield(Key, YieldTO) of
+        {value, R} -> R
+    end.
+
+%% @doc Simple server non-blocking yield with key, default timeout value of 0
+nb_yield(Key)->
+    nb_yield(Key, 0).
+
+%% @doc Simple server non-blocking yield with key and custom timeout value
+nb_yield(Key, Timeout) when is_pid(Key), ?is_timeout(Timeout) ->
+    receive 
+            {Key, {promise_reply, Reply}} -> {value, Reply};
+            {badtcp, Reason} ->
+                    ok = lager:notice("function=nb_yield event=call_bad_tcp yield_key=\"~p\" reason=\"~p\"", [Key, Reason]),
+                    {value, {badtcp, Reason}};
+            UnknownMsg -> 
+                    ok = lager:notice("function=nb_yield event=unknown_msg yield_key=\"~p\" message=\"~p\"", [Key, UnknownMsg]),
+                    {value, {badrpc, timeout}}
+    after Timeout ->
+            ok = lager:notice("function=nb_yield event=call_timeout yield_key=\"~p\"", [Key]),
+            {value, {badrpc, timeout}}
+    end.
+
 %%% ===================================================
 %%% Behaviour callbacks
 %%% ===================================================
@@ -206,7 +277,7 @@ init({Node}) ->
     %% Perform an in-band RPC call to the remote node
     %% asking it to launch a listener for us and return us
     %% the port that has been allocated for us
-    ok = lager:info("function=init event=initializing_client server_node=\"~s\" connect_timeout=~B send_timeout=~B receive_timeout=~B inactivity_timeout=~p",
+    ok = lager:info("function=init event=initializing_client server_node=\"~s\" connect_timeout=~B send_timeout=~B receive_timeout=~B inactivity_timeout=\"~p\"",
                     [Node, ConnTO, SendTO, RecvTO, TTL]),
     case rpc:call(Node, gen_rpc_server_sup, start_child, [node()], ConnTO) of
         {ok, Port} ->
@@ -422,6 +493,23 @@ call_worker(Ref, Caller, Timeout) when is_tuple(Caller), is_reference(Ref) ->
             ok = lager:notice("function=call_worker event=call_timeout call_reference=\"~p\"", [Ref]),
             _Ign = gen_server:reply(Caller, {badrpc, timeout})
     end.
+
+yield_results([]) -> [[],[]];
+yield_results(Keys) ->
+    Results = lists:map(fun({Node, Key}) -> 
+                              Reply = nb_yield(Key, infinity),
+                              case normalize_result(Reply) of 
+                                   bad -> {bad, Node};
+                                   Else -> Else
+                              end
+                        end, Keys), 
+    BadNodes = [Node || {bad, Node}  <- Results],
+    GoodResults = [Result || {value, Result}  <- Results],
+    [GoodResults, BadNodes]. 
+
+normalize_result({value, {badrpc, _}}) -> bad;
+normalize_result({value, {badtcp, _}}) -> bad;
+normalize_result({value, Result}) -> {value, Result}.
 
 %% Merges user-define timeout values with state timeout values
 merge_timeout_values(SRecvTO, undefined, SSendTO, undefined) ->

--- a/test/ct/local_functional_SUITE.erl
+++ b/test/ct/local_functional_SUITE.erl
@@ -106,7 +106,7 @@ call_mfa_exit(_Config) ->
 call_mfa_throw(_Config) ->
     ok = ct:pal("Testing [call_mfa_throw]"),
     'throwXdown' = gen_rpc:call(?NODE, erlang, throw, ['throwXdown']),
-    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
+    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={throwXdown}").
 
 call_with_receive_timeout(_Config) ->
     ok = ct:pal("Testing [call_with_receive_timeout]"),
@@ -193,6 +193,81 @@ safe_cast_mfa_throw(_Config) ->
 safe_cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [safe_cast_inexistent_node]"),
     {badrpc, nodedown} = gen_rpc:safe_cast(?FAKE_NODE, os, timestamp, [], 1000).
+
+async_call(_Config) ->
+    ok = ct:pal("Testing [async_call]"),
+    YieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
+    NbYieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    {value,{_,_,_}}= gen_rpc:nb_yield(NbYieldKey0, 1000),
+    YieldKey = gen_rpc:async_call(?NODE, io_lib, print, [yield_key]),
+    "yield_key" = gen_rpc:yield(YieldKey),
+    NbYieldKey = gen_rpc:async_call(?NODE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 1000).
+
+async_call_anonymous_function(_Config) ->
+    ok = ct:pal("Testing [async_call_anonymous_function]"),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
+                                                     [yield_key_anonymous_func]]),
+    {_, "yield_key_anonymous_func"} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
+                                                     [nb_yield_key_anonymous_func]]),
+    {value, {_, "nb_yield_key_anonymous_func"}} = gen_rpc:nb_yield(NBYieldKey, 1000).
+
+async_call_anonymous_undef(_Config) ->
+    ok = ct:pal("Testing [async_call_anonymous_undef]"),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 1000),
+    ok = ct:pal("Result [async_call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_undef]"),
+    YieldKey = gen_rpc:async_call(?NODE, os, timestamp_undef),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, os, timestamp_undef),
+    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 2000),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_exit]"),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, exit, ['die']),
+    {badrpc, {'EXIT', die}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, exit, ['die']),
+    {value, {badrpc, {'EXIT', die}}} = gen_rpc:nb_yield(NBYieldKey, 1000),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_throw]"),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, throw, ['throwXdown']),
+    'throwXdown' = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, throw, ['throwXdown']),
+    {value, 'throwXdown'} = gen_rpc:nb_yield(NBYieldKey, 1000),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=throw Reason={throwXdown}").
+
+async_call_yield_timeout(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_timeout]"),
+    YieldKey = gen_rpc:async_call(?NODE, timer, sleep, [1000]),
+    {badrpc,timeout} = gen_rpc:yield(YieldKey, 5),
+    NBYieldKey = gen_rpc:async_call(?NODE, timer, sleep, [1000]),
+    {value, {badrpc,timeout}} = gen_rpc:nb_yield(NBYieldKey, 5),
+    ok = ct:pal("Result [async_call_yield_timeout]: signal=timeout Reason={timeout}").
+
+async_call_nb_yield_infinity(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_infinity]"),
+    YieldKey = gen_rpc:async_call(?NODE, timer, sleep, [1000]),
+    ok = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, timer, sleep, [1000]),
+    {value, ok} = gen_rpc:nb_yield(NBYieldKey, infinity),
+    ok = ct:pal("Result [async_call_yield_infinity]: signal=sleep Reason={ok}").
+
+async_call_inexistent_node(_Config) ->
+    ok = ct:pal("Testing [async_call_inexistent_node]"),
+    YieldKey1 = gen_rpc:async_call(?FAKE_NODE, os, timestamp, []),
+    {badrpc, nodedown} = gen_rpc:yield(YieldKey1),
+    YieldKey2 = gen_rpc:async_call(?FAKE_NODE, os, timestamp, []),
+    {value, {badrpc, nodedown}} = gen_rpc:nb_yield(YieldKey2, 5000).
 
 client_inactivity_timeout(_Config) ->
     ok = ct:pal("Testing [client_inactivity_timeout]"),

--- a/test/ct/multi_rpc_functional_SUITE.erl
+++ b/test/ct/multi_rpc_functional_SUITE.erl
@@ -55,8 +55,15 @@ eval_everywhere_mfa_no_node(_Config) ->
     true = erlang:is_process_alive(whereis(gen_rpc_acceptor_sup)),
     true = erlang:is_process_alive(whereis(gen_rpc_client_sup)).
 
+%% Eval_everywhere is fire and forget, which means some test cases need to show
+%% something has been executed on target nodes. 
+%% The main technique used in eval_everywhere testing is to setup servers- slaves,
+%% and have the test script to ping the slaves with tagged messages and then wait for 
+%% such and match the tags to verify originality.
+
 %% Ping the target node with tagged msg. Target Node reply back with
 %% tagged msg and its own identity.
+ 
 eval_everywhere_mfa_one_node(_Config) ->
     ok = ct:pal("Testing [eval_everywhere_mfa_one_node]"),
     ConnectedNodes = [?SLAVE1],

--- a/test/ct/remote_functional_SUITE.erl
+++ b/test/ct/remote_functional_SUITE.erl
@@ -62,7 +62,6 @@ end_per_testcase(_OtherTest, Config) ->
     ok = gen_rpc_test_helper:stop_slave(?SLAVE),
     Config.
 
-
 %%% ===================================================
 %%% Test cases
 %%% ===================================================
@@ -171,6 +170,76 @@ safe_cast_mfa_throw(_Config) ->
 safe_cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [safe_cast_inexistent_node]"),
     {badrpc, nodedown} = gen_rpc:safe_cast(?FAKE_NODE, os, timestamp, [], 1000).
+
+async_call(_Config) ->
+    ok = ct:pal("Testing [async_call]"),
+    YieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
+    NbYieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    {value,{_,_,_}}= gen_rpc:nb_yield(NbYieldKey0, 1000),
+    YieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [yield_key]),
+    "yield_key" = gen_rpc:yield(YieldKey),
+    NbYieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
+
+async_call_yield_reentrant(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_reentrant]"),
+    YieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
+    Pid = proc_lib:spawn(fun()->
+                                {value, {badrpc, timeout}} = gen_rpc:yield(YieldKey0),
+                                ok = ct:pal("yield/1 waits forever. Should never see this.")
+                         end),
+    {ok, _} = timer:kill_after(5000, Pid),
+    NbYieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    % Verify not able to reuse Key again. Key is one time use.
+    {_,_,_} = gen_rpc:yield(NbYieldKey0, 100),
+    {value, {badrpc, timeout}} = gen_rpc:nb_yield(NbYieldKey0, 10),
+    YieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [yield_key]),
+    "yield_key" = gen_rpc:yield(YieldKey),
+    {badrpc, timeout} = gen_rpc:yield(YieldKey, 100),
+    NbYieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
+
+async_call_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_undef]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, os, timestamp_undef),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, os, timestamp_undef),
+    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 2000),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_exit]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, erlang, exit, ['die']),
+    {badrpc, {'EXIT', die}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, erlang, exit, ['die']),
+    {value, {badrpc, {'EXIT', die}}} = gen_rpc:nb_yield(NBYieldKey, 1000),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
+
+async_call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [async_call_mfa_throw]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, erlang, throw, ['throwXdown']),
+    'throwXdown' = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, erlang, throw, ['throwXdown']),
+    {value, 'throwXdown'} = gen_rpc:nb_yield(NBYieldKey, 1000),
+    ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={throwXdown}").
+
+async_call_yield_timeout(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_timeout]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    {badrpc,timeout} = gen_rpc:yield(YieldKey, 5),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    {value, {badrpc,timeout}} = gen_rpc:nb_yield(NBYieldKey, 5),
+    ok = ct:pal("Result [async_call_yield_timeout]: signal=EXIT Reason={timeout}").
+
+async_call_nb_yield_infinity(_Config) ->
+    ok = ct:pal("Testing [async_call_yield_infinity]"),
+    YieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    ok = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    {value, ok} = gen_rpc:nb_yield(NBYieldKey, infinity),
+    ok = ct:pal("Result [async_call_yield_infinity]: signal=EXIT Reason={ok}").
 
 client_inactivity_timeout(_Config) ->
     ok = ct:pal("Testing [client_inactivity_timeout]"),

--- a/test/gen_rpc/multi_rpc_functional_SUITE.erl
+++ b/test/gen_rpc/multi_rpc_functional_SUITE.erl
@@ -1,0 +1,127 @@
+%%% -*-mode:erlang;coding:utf-8;tab-width:4;c-basic-offset:4;indent-tabs-mode:()-*-
+%%% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+%%%
+%%% Copyright 2015 Panagiotis Papadomitsos. All Rights Reserved.
+%%%
+
+-module(multi_rpc_functional_SUITE).
+-author("Panagiotis Papadomitsos <pj@ezgr.net>").
+
+%%% CT Macros
+-include_lib("test/include/ct.hrl").
+
+%%% No need to export anything, everything is automatically exported
+%%% as part of the test profile
+
+-define(TESTSRV, test_app_server).
+
+%%% ===================================================
+%%% CT callback functions
+%%% ===================================================
+all() ->
+    gen_rpc_test_helper:get_test_functions(?MODULE).
+
+init_per_suite(Config) ->
+    %% Starting Distributed Erlang on local node
+    {ok, _Pid} = gen_rpc_test_helper:start_distribution(?NODE),
+    %% Setup application logging
+    ok = gen_rpc_test_helper:set_application_environment(),
+    %% Starting the application locally
+    {ok, _MasterApps} = application:ensure_all_started(?APP),
+    ok = ct:pal("Started [remote_functional] suite with master node [~s]", [node()]),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(client_inactivity_timeout, Config) ->
+    ok = start_slaves(),
+    ok = gen_rpc_test_helper:restart_application(),
+    ok = application:set_env(?APP, client_inactivity_timeout, infinity),
+    Config;
+
+init_per_testcase(server_inactivity_timeout, Config) ->
+    ok = start_slaves(),
+    ok = gen_rpc_test_helper:restart_application(),
+    ok = application:set_env(?APP, server_inactivity_timeout, infinity),
+    Config;
+
+init_per_testcase(_OtherTest, Config) ->
+    ok = start_slaves(),
+    Config.
+
+end_per_testcase(client_inactivity_timeout, Config) ->
+    ok = stop_slaves(),
+    ok = gen_rpc_test_helper:restart_application(),
+    Config;
+
+end_per_testcase(server_inactivity_timeout, Config) ->
+    ok = stop_slaves(),
+    ok = gen_rpc_test_helper:restart_application(),
+    Config;
+
+end_per_testcase(_OtherTest, Config) ->
+    ok = stop_slaves(),
+    Config.
+
+%%% ===================================================
+%%% Test cases
+%%% ===================================================
+%% Test main functions
+multi_call(_Config) ->
+    ok = ct:pal("Testing [multi_call]"),
+    [[?SLAVE1,?SLAVE2], []] = gen_rpc:multicall([?SLAVE1, ?SLAVE2], erlang, node, 5000, 100).
+
+multi_call_timeout(_Config) ->
+    ok = ct:pal("Testing [multi_call_timeout]"),
+    [[], [?SLAVE1]] = gen_rpc:multicall([?SLAVE1], timer, sleep, [10000], 1, 1).
+
+multi_call_mfa_undef(_Config) ->
+    ok = ct:pal("Testing [multi_call_mfa_undef]"),
+    [[], [?SLAVE1,?SLAVE2]] = gen_rpc:multicall([?SLAVE1, ?SLAVE2], erlang, undef, ['die'], 5000, 100).
+
+multi_call_mfa_exit(_Config) ->
+    ok = ct:pal("Testing [multi_call_mfa_exit]"),
+    [[], [?SLAVE1,?SLAVE2]] = gen_rpc:multicall([?SLAVE1, ?SLAVE2], erlang, exit, ['die'], 5000, 100).
+
+multi_call_mfa_throw(_Config) ->
+    ok = ct:pal("Testing [multi_call_mfa_throw]"),
+    [['throwXdown', 'throwXdown'], []] = gen_rpc:multicall([?SLAVE1, ?SLAVE2], erlang, throw, ['throwXdown'], 5000, 100).
+
+multi_call_inexistent_node(_Config) ->
+    ok = ct:pal("Testing [multi_call_inexistent_node]"),
+    [[], [?FAKE_NODE]] = gen_rpc:multicall([?FAKE_NODE], os, timestamp, 10, 10).
+
+multi_call_no_node(_Config) ->
+    ok = ct:pal("Testing [multi_call_no_node]"),
+    [[],[]] = gen_rpc:multicall([], os, timestamp, 10, 10).
+
+multi_call_multiple_nodes_fail_end(_Config) ->
+    ok = ct:pal("Testing [multi_call_multiple_nodes]"),
+    ok = ct:pal("Case 1: Failed node at end of list"),
+    [[_,_],[?FAKE_NODE]] = gen_rpc:multicall([?SLAVE1, ?SLAVE2, ?FAKE_NODE], os, timestamp, 5000, 100).
+
+multi_call_multiple_nodes_fail_middle(_Config) ->
+    ok = ct:pal("Testing [multi_call_multiple_nodes]"),
+    ok = ct:pal("Case 2: Failed node at end of list"),
+    [[_,_],[?FAKE_NODE]] = gen_rpc:multicall([?SLAVE1, ?FAKE_NODE, ?SLAVE2], os, timestamp, 5000, 100).
+
+multi_call_multiple_nodes_fail_start(_Config) ->
+    ok = ct:pal("Testing [multi_call_multiple_nodes]"),
+    ok = ct:pal("Case 3: Failed node at start of list"),
+    [[_,_],[?FAKE_NODE]] = gen_rpc:multicall([?FAKE_NODE, ?SLAVE1, ?SLAVE2], os, timestamp, 5000, 100).
+
+
+%%% ===================================================
+%%% Auxiliary functions for test cases
+%%% ===================================================
+start_slaves() ->
+    ok = gen_rpc_test_helper:start_slave(?SLAVE1),
+    ok = gen_rpc_test_helper:start_slave(?SLAVE2),
+    ok = ct:pal("Slaves started"),
+    ok.
+
+stop_slaves() ->
+    ok = gen_rpc_test_helper:stop_slave(?SLAVE1),
+    ok = gen_rpc_test_helper:stop_slave(?SLAVE2),
+    ok = ct:pal("Slaves stopped").


### PR DESCRIPTION
Implementation of 
* multicall(Nodes, M, F, RecvTO, SendTO)
* multicall(Nodes, M, F, A,  RecvTO, SendTO)
rpc multicall requires that the call be sent concurrently to all nodes & failure on individual node won't affect requests to other nodes.
- use async to establish peer gen_rpc_server process and execute M,F,A on each node, so won't block
- gather results from nb_yield to filter for Results and Badnodes
- If Nodes is [], returns both Results and BadNodes are []

This PR uses async and yield so is related to 
https://github.com/priestjim/gen_rpc/pull/43
Cleaned up  version of https://github.com/priestjim/gen_rpc/pull/30