### PR TITLE
Refactor async_call, implement multicall and other

### DIFF
--- a/gen_rpc.config
+++ b/gen_rpc.config
@@ -1,0 +1,18 @@
+%%% -*-mode:erlang;coding:utf-8;tabidth,:4;c-basic-offset:4;indent-tabs-mode:()-*-
+%%% ex: set ft=erlang fenc=utf-8 sts=4 ts=4 sw=4 et:
+%%%
+[
+    {sasl, [
+        {errlog_type, error},
+        {error_logger_mf_dir, false}
+    ]},
+    {lager, [
+        {colored, true},
+        {handlers, [
+            {lager_console_backend, [debug,
+                {lager_default_formatter, ["[", date, " ", time, "] severity=", severity, " node=\"", {node, "undefined"}, "\" pid=\"", pid,
+                    "\" module=", {module, "gen_rpc"}, " function=", {function, "undefined"}, " ", message, "\n"]}
+            ]}
+        ]}
+    ]}
+].

--- a/otp-release.escript
+++ b/otp-release.escript
@@ -1,12 +1,12 @@
 #!/usr/bin/env escript
 main(_Options) ->
-    OtpRelease = otp_release1(erlang:system_info(otp_release)),
+    OtpRelease = otp_release(erlang:system_info(otp_release)),
     ok = io:format("~s", [OtpRelease]).
 
 %% Copied from https://github.com/rebar/rebar3/blob/master/src/rebar_utils.erl
-otp_release1([$R,N|_]=Rel) when is_integer(N) ->
+otp_release([$R,N|_]=Rel) when is_integer(N) ->
     Rel;
-otp_release1(Rel) ->
+otp_release(Rel) ->
     File = filename:join([code:root_dir(), "releases", Rel, "OTP_VERSION"]),
     case file:read_file(File) of
         {error, _} ->

--- a/package.exs
+++ b/package.exs
@@ -1,4 +1,4 @@
-defmodule FS.Mixfile do
+defmodule GenRPC.Mixfile do
   use Mix.Project
 
   def project do

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,10 @@
 
 %% Plugins
 {plugins, []}.
-{shell_apps, [gen_rpc]}.
+{shell, [
+    {apps, [sync, gen_rpc]},
+    {config, "gen_rpc.config"}
+]}.
 
 {erl_opts, [debug_info,
     {warn_format, 1},
@@ -34,15 +37,20 @@
 ]}.
 
 {deps, [
-    {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "3.0.2"}}}
+    {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "3.1.0"}}}
 ]}.
 
 {profiles, [
     {test, [
         {erl_opts, [warnings_as_errors, debug_info, export_all, no_inline_list_funcs]},
         {deps, [
-            {sync, ".*", {git, "git://github.com/rustyio/sync.git", {branch, "master"}}},
             {eunit_formatters, {git, "git://github.com/seancribbs/eunit_formatters", {branch, "master"}}}
+        ]}
+    ]},
+    {dev, [
+        {erl_opts, [warnings_as_errors, debug_info, export_all, no_inline_list_funcs]},
+        {deps, [
+            {sync, ".*", {git, "git://github.com/rustyio/sync.git", {branch, "master"}}}
         ]}
     ]}
 ]}.

--- a/src/gen_rpc.app.src
+++ b/src/gen_rpc.app.src
@@ -20,7 +20,9 @@
         %% Inactivity timeout for client gen_server
         {client_inactivity_timeout, infinity},
         %% Inactivity timeout for server gen_server
-        {server_inactivity_timeout, infinity}
+        {server_inactivity_timeout, infinity},
+        %% Orphan async call process timeout
+        {async_call_inactivity_timeout, infinity}
     ]},
     {modules, []}]
 }.

--- a/src/gen_rpc.erl
+++ b/src/gen_rpc.erl
@@ -8,27 +8,22 @@
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% Library interface
--export([async_call/3,
-        async_call/4,
-        call/3,
-        call/4,
-        call/5,
-        call/6,
-        cast/3,
-        cast/4,
-        cast/5,
-        eval_everywhere/3,
-        eval_everywhere/4,
-        eval_everywhere/5,
-        yield/1,
-        nb_yield/1,
-        nb_yield/2,
-        safe_cast/3,
-        safe_cast/4,
-        safe_cast/5,
-        safe_eval_everywhere/3,
-        safe_eval_everywhere/4,
-        safe_eval_everywhere/5]).
+-export([call/3, call/4, call/5, call/6]).
+
+%% Async calls
+-export([async_call/3, async_call/4, yield/1, nb_yield/1, nb_yield/2]).
+
+%% Cast and safe_cast
+-export([cast/3, cast/4, cast/5, safe_cast/3, safe_cast/4, safe_cast/5]).
+
+%% Parallel evaluation
+-export([eval_everywhere/3, eval_everywhere/4, eval_everywhere/5, safe_eval_everywhere/3, safe_eval_everywhere/4, safe_eval_everywhere/5]).
+
+%% Parallel sync call
+-export([multicall/3, multicall/4, multicall/5]).
+
+%% Misc functions
+-export([nodes/0]).
 
 %%% ===================================================
 %%% Library interface
@@ -71,23 +66,14 @@ cast(Node, M, F, A) ->
 cast(Node, M, F, A, SendTO) ->
     gen_rpc_client:cast(Node, M, F, A, SendTO).
 
-%% @doc Evaluates asynchronously apply(Nodes, Module, Function) on the specified nodes.
-%% The function returns immediately after sending request. No answers, warnings or errors are collected.
-%% It's fire and forget
 -spec eval_everywhere(Nodes::[node()], M::module(), F::atom()|function()) -> 'abcast'.
 eval_everywhere(Nodes, M, F) ->
     gen_rpc_client:eval_everywhere(Nodes, M, F).
 
-%% @doc Evaluates asynchronously apply(Nodes, Module, Function, Args) on the specified nodes.
-%% The function returns immediately after sending request. No answers, warnings or errors are collected.
-%% It's fire and forget
 -spec eval_everywhere(Nodes::[node()], M::module(), F::atom()|function(), A::list()) -> 'abcast'.
 eval_everywhere(Nodes, M, F, A) ->
     gen_rpc_client:eval_everywhere(Nodes, M, F, A).
 
-%% @doc Evaluates asynchronously apply(Nodes, Module, Function, Args) on the specified nodes.
-%% The function returns immediately after sending request. No answers, warnings or errors are collected.
-%% It's fire and forget
 -spec eval_everywhere(Nodes::[node()], M::module(), F::atom()|function(), A::list(), SendTO::timeout()) -> 'abcast'.
 eval_everywhere(Nodes, M, F, A, SendTO) ->
     gen_rpc_client:eval_everywhere(Nodes, M, F, A, SendTO).
@@ -104,33 +90,42 @@ safe_cast(Node, M, F, A) ->
 safe_cast(Node, M, F, A, SendTO) ->
     gen_rpc_client:safe_cast(Node, M, F, A, SendTO).
 
-%% @doc Evaluates asynchronously apply(Nodes, Module, Function) on the specified nodes.
-%% The function returns list of nodes that succeeded or errored out.
 -spec safe_eval_everywhere(Nodes::[node()], M::module(), F::atom()|function()) -> ['true'  | [node()]].
 safe_eval_everywhere(Nodes, M, F) ->
     gen_rpc_client:safe_eval_everywhere(Nodes, M, F).
 
-%% @doc Evaluates asynchronously apply(Nodes, Module, Function, Args) on the specified nodes.
-%% The function returns list of nodes that succeeded or errored out.
 -spec safe_eval_everywhere(Nodes::[node()], M::module(), F::atom()|function(), A::list()) ->  ['true'  | [node()]].
 safe_eval_everywhere(Nodes, M, F, A) ->
     gen_rpc_client:safe_eval_everywhere(Nodes, M, F, A).
 
-%% @doc Evaluates asynchronously apply(Nodes, Module, Function, Args) on the specified nodes.
-%% The function returns list of that succeeded or errored out.
 -spec safe_eval_everywhere(Nodes::[node()], M::module(), F::atom()|function(), A::list(), SendTO::timeout()) ->  ['true'  | [node()]].
 safe_eval_everywhere(Nodes, M, F, A, SendTO) ->
     gen_rpc_client:safe_eval_everywhere(Nodes, M, F, A, SendTO).
 
--spec yield(Key::pid()) -> term() | {badrpc, term()}.
+-spec yield(Key::tuple()) -> term() | {badrpc, term()}.
 yield(Key) ->
     gen_rpc_client:yield(Key).
 
--spec nb_yield(Key::pid()) -> {value, term()} | {badrpc, term()}.
+-spec nb_yield(Key::tuple()) -> {value, term()} | {badrpc, term()}.
 nb_yield(Key) ->
     gen_rpc_client:nb_yield(Key).
 
--spec nb_yield(Key::pid(), Timeout::timeout()) -> {value, term()} | {badrpc, term()}.
+-spec nb_yield(Key::tuple(), Timeout::timeout()) -> {value, term()} | {badrpc, term()}.
 nb_yield(Key, Timeout) ->
     gen_rpc_client:nb_yield(Key, Timeout).
 
+-spec multicall(M::module(), F::atom(), A::list()) -> {list(), list()}.
+multicall(M, F, A) ->
+    gen_rpc_client:multicall(M, F, A).
+
+-spec multicall(NodesOrModule::list() | module(), MorF::module() | atom(), ForA::atom() | list(), AorTimeout::list() | timeout()) -> {list(), list()}.
+multicall(NodesOrModule, MorF, ForA, AorTimeout) ->
+    gen_rpc_client:multicall(NodesOrModule, MorF, ForA, AorTimeout).
+
+-spec multicall(Nodes::list(), M::module(), F::atom(), A::list(), Timeout::timeout()) -> {list(), list()}.
+multicall(Nodes, M, F, A, Timeout) ->
+    gen_rpc_client:multicall(Nodes, M, F, A, Timeout).
+
+-spec nodes() -> list().
+nodes() ->
+    gen_rpc_client_sup:children_names().

--- a/src/gen_rpc_dispatcher.erl
+++ b/src/gen_rpc_dispatcher.erl
@@ -41,45 +41,45 @@ start_client(Node) when is_atom(Node) ->
 %%% Behaviour callbacks
 %%% ===================================================
 init([]) ->
-    ok = lager:info("function=init"),
+    ok = lager:info("event=start"),
     process_flag(trap_exit, true),
-    {ok, no_state}.
+    {ok, undefined}.
 
 %% Simply launch a connection to a node through the appropriate
 %% supervisor. This is a serialization interface so that
-handle_call({start_client, Node}, _Caller, no_state) ->
+handle_call({start_client, Node}, _Caller, undefined) ->
     Reply = case whereis(Node) of
         undefined ->
-            ok = lager:debug("function=handle_call message=start_client event=starting_client_server server_node=\"~s\"", [Node]),
+            ok = lager:debug("message=start_client event=starting_client_server server_node=\"~s\"", [Node]),
             gen_rpc_client_sup:start_child(Node);
         Pid ->
-            ok = lager:debug("function=handle_call message=start_client event=node_already_started server_node=\"~s\"", [Node]),
+            ok = lager:debug("message=start_client event=node_already_started server_node=\"~s\"", [Node]),
             {ok, Pid}
     end,
-    {reply, Reply, no_state};
+    {reply, Reply, undefined};
 
 %% Gracefully terminate
-handle_call(stop, _Caller, no_state) ->
-    {stop, normal, ok, no_state};
+handle_call(stop, _Caller, undefined) ->
+    {stop, normal, ok, undefined};
 
 %% Catch-all for calls - die if we get a message we don't expect
-handle_call(Msg, _Caller, no_state) ->
-    ok = lager:critical("function=handle_call event=uknown_call_received message=\"~p\" action=stopping", [Msg]),
-    {stop, {unknown_call, Msg}, no_state}.
+handle_call(Msg, _Caller, undefined) ->
+    ok = lager:critical("event=uknown_call_received message=\"~p\" action=stopping", [Msg]),
+    {stop, {unknown_call, Msg}, undefined}.
 
 %% Catch-all for casts - die if we get a message we don't expect
-handle_cast(Msg, no_state) ->
-    ok = lager:critical("function=handle_call event=uknown_cast_received message=\"~p\" action=stopping", [Msg]),
-    {stop, {unknown_cast, Msg}, no_state}.
+handle_cast(Msg, undefined) ->
+    ok = lager:critical("event=uknown_cast_received message=\"~p\" action=stopping", [Msg]),
+    {stop, {unknown_cast, Msg}, undefined}.
 
 %% Catch-all for info - our protocol is strict so die!
-handle_info(Msg, no_state) ->
-    ok = lager:critical("function=handle_info event=uknown_message_received message=\"~p\" action=stopping", [Msg]),
-    {stop, {unknown_info, Msg}, no_state}.
+handle_info(Msg, undefined) ->
+    ok = lager:critical("event=uknown_message_received message=\"~p\" action=stopping", [Msg]),
+    {stop, {unknown_info, Msg}, undefined}.
 
-code_change(_OldVersion, no_state, _Extra) ->
-    {ok, no_state}.
+code_change(_OldVersion, undefined, _Extra) ->
+    {ok, undefined}.
 
-terminate(Reason, no_state) ->
-    ok = lager:debug("function=terminate reason=\"~512tp\"", [Reason]),
+terminate(Reason, undefined) ->
+    ok = lager:debug("reason=\"~512tp\"", [Reason]),
     ok.

--- a/src/gen_rpc_helper.erl
+++ b/src/gen_rpc_helper.erl
@@ -7,9 +7,15 @@
 -module(gen_rpc_helper).
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
+%%% Include this library's name macro
 -include("app.hrl").
 
+%%% Public API
 -export([otp_release/0, default_tcp_opts/1, make_process_name/2]).
+
+%%% ===================================================
+%%% Public API
+%%% ===================================================
 
 -spec otp_release() -> integer().
 otp_release() ->

--- a/src/supervisor/gen_rpc_acceptor_sup.erl
+++ b/src/supervisor/gen_rpc_acceptor_sup.erl
@@ -19,11 +19,12 @@
 %%% ===================================================
 %%% Supervisor functions
 %%% ===================================================
+-spec start_link() -> supervisor:startlink_ret().
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 start_child(ClientIp, Node) when is_tuple(ClientIp), is_atom(Node) ->
-    ok = lager:debug("function=start_child event=starting_new_acceptor client_ip=\"~p\" client_node=\"~s\"", [ClientIp, Node]),
+    ok = lager:debug("event=starting_new_acceptor client_ip=\"~p\" client_node=\"~s\"", [ClientIp, Node]),
     case supervisor:start_child(?MODULE, [ClientIp, Node]) of
         {error, {already_started, CPid}} ->
             %% If we've already started the child, terminate it and start anew
@@ -37,7 +38,7 @@ start_child(ClientIp, Node) when is_tuple(ClientIp), is_atom(Node) ->
 
 -spec stop_child(Pid::pid()) ->  'ok'.
 stop_child(Pid) when is_pid(Pid) ->
-    ok = lager:debug("function=stop_child event=stopping_acceptor acceptor_pid=\"~p\"", [Pid]),
+    ok = lager:debug("event=stopping_acceptor acceptor_pid=\"~p\"", [Pid]),
     _ = supervisor:terminate_child(?MODULE, Pid),
     _ = supervisor:delete_child(?MODULE, Pid),
     ok.

--- a/src/supervisor/gen_rpc_server_sup.erl
+++ b/src/supervisor/gen_rpc_server_sup.erl
@@ -19,13 +19,14 @@
 %%% ===================================================
 %%% Supervisor functions
 %%% ===================================================
+-spec start_link() -> supervisor:startlink_ret().
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 %% Launch a local receiver and return the port
 -spec start_child(Node::node()) -> {'ok', inet:port_number()} | {ok, _}.
 start_child(Node) when is_atom(Node) ->
-    ok = lager:debug("function=start_child event=starting_new_server client_node=\"~s\"", [Node]),
+    ok = lager:debug("event=starting_new_server client_node=\"~s\"", [Node]),
     {ok, Pid} = case supervisor:start_child(?MODULE, [Node]) of
         {error, {already_started, CPid}} ->
             %% If we've already started the child, terminate it and start anew
@@ -42,12 +43,11 @@ start_child(Node) when is_atom(Node) ->
 %% Terminate and unregister a child server
 -spec stop_child(Pid::pid()) -> 'ok'.
 stop_child(Pid) when is_pid(Pid) ->
-    ok = lager:debug("function=stop_child event=stopping_server server_pid=\"~p\"", [Pid]),
+    ok = lager:debug("event=stopping_server server_pid=\"~p\"", [Pid]),
     %% Terminate the acceptor child first and then
     _ = supervisor:terminate_child(?MODULE, Pid),
     _ = supervisor:delete_child(?MODULE, Pid),
     ok.
-
 
 %%% ===================================================
 %%% Supervisor callbacks

--- a/src/supervisor/gen_rpc_sup.erl
+++ b/src/supervisor/gen_rpc_sup.erl
@@ -19,6 +19,7 @@
 %%% ===================================================
 %%% Supervisor functions
 %%% ===================================================
+-spec start_link() -> supervisor:startlink_ret().
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 

--- a/test/ct/local_SUITE.erl
+++ b/test/ct/local_SUITE.erl
@@ -4,7 +4,7 @@
 %%% Copyright 2015 Panagiotis Papadomitsos. All Rights Reserved.
 %%%
 
--module(remote_functional_SUITE).
+-module(local_SUITE).
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% CT Macros
@@ -26,77 +26,90 @@ init_per_suite(Config) ->
     ok = gen_rpc_test_helper:set_application_environment(),
     %% Starting the application locally
     {ok, _MasterApps} = application:ensure_all_started(?APP),
-    ok = ct:pal("Started [remote_functional] suite with master node [~s]", [node()]),
+    ok = ct:pal("Started [local_functional] suite with master node [~s]", [node()]),
     Config.
 
 end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(client_inactivity_timeout, Config) ->
-    ok = gen_rpc_test_helper:start_slave(?SLAVE),
     ok = gen_rpc_test_helper:restart_application(),
     ok = gen_rpc_test_helper:set_application_environment(),
-    ok = application:set_env(?APP, client_inactivity_timeout, infinity),
+    ok = application:set_env(?APP, client_inactivity_timeout, 500),
     Config;
 
 init_per_testcase(server_inactivity_timeout, Config) ->
-    ok = gen_rpc_test_helper:start_slave(?SLAVE),
     ok = gen_rpc_test_helper:restart_application(),
     ok = gen_rpc_test_helper:set_application_environment(),
-    ok = application:set_env(?APP, server_inactivity_timeout, infinity),
+    ok = application:set_env(?APP, server_inactivity_timeout, 500),
+    Config;
+
+init_per_testcase(async_call_inexistent_node, Config) ->
+    ok = gen_rpc_test_helper:restart_application(),
+    ok = gen_rpc_test_helper:set_application_environment(),
+    Config;
+
+init_per_testcase(remote_node_call, Config) ->
+    ok = gen_rpc_test_helper:start_slave(?SLAVE),
     Config;
 
 init_per_testcase(_OtherTest, Config) ->
-    ok = gen_rpc_test_helper:start_slave(?SLAVE),
     Config.
 
 end_per_testcase(client_inactivity_timeout, Config) ->
-    ok = gen_rpc_test_helper:stop_slave(?SLAVE),
-    ok = gen_rpc_test_helper:restart_application(),
-    ok = gen_rpc_test_helper:set_application_environment(),
+    ok = application:set_env(?APP, client_inactivity_timeout, infinity),
     Config;
 
 end_per_testcase(server_inactivity_timeout, Config) ->
+    ok = application:set_env(?APP, server_inactivity_timeout, infinity),
+    Config;
+
+end_per_testcase(remote_node_call, Config) ->
     ok = gen_rpc_test_helper:stop_slave(?SLAVE),
-    ok = gen_rpc_test_helper:restart_application(),
-    ok = gen_rpc_test_helper:set_application_environment(),
     Config;
 
 end_per_testcase(_OtherTest, Config) ->
-    ok = gen_rpc_test_helper:stop_slave(?SLAVE),
     Config.
-
 
 %%% ===================================================
 %%% Test cases
 %%% ===================================================
+%% Test supervisor's status
+supervisor_black_box(_Config) ->
+    true = erlang:is_process_alive(whereis(gen_rpc_server_sup)),
+    true = erlang:is_process_alive(whereis(gen_rpc_acceptor_sup)),
+    true = erlang:is_process_alive(whereis(gen_rpc_client_sup)),
+    ok.
+
 %% Test main functions
 call(_Config) ->
-    ok = ct:pal("Testing [call]"),
-    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp).
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?NODE, os, timestamp).
+
+call_anonymous_function(_Config) ->
+    {_,"\"call_anonymous_function\""} = gen_rpc:call(?NODE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
+                                                     ["call_anonymous_function"]]).
+
+call_anonymous_undef(_Config) ->
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}}  = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+   ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_undef(_Config) ->
-    ok = ct:pal("Testing [call_mfa_undef]"),
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?SLAVE, os, timestamp_undef),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, os, timestamp_undef),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_exit(_Config) ->
-    ok = ct:pal("Testing [call_mfa_exit]"),
-    {badrpc, {'EXIT', die}} = gen_rpc:call(?SLAVE, erlang, exit, ['die']),
+    {badrpc, {'EXIT', die}} = gen_rpc:call(?NODE, erlang, exit, ['die']),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
 
 call_mfa_throw(_Config) ->
-    ok = ct:pal("Testing [call_mfa_throw]"),
-    'throwXdown' = gen_rpc:call(?SLAVE, erlang, throw, ['throwXdown']),
-    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
+    'throwXdown' = gen_rpc:call(?NODE, erlang, throw, ['throwXdown']),
+    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={throwXdown}").
 
 call_with_receive_timeout(_Config) ->
-    ok = ct:pal("Testing [call_with_receive_timeout]"),
-    {badrpc, timeout} = gen_rpc:call(?SLAVE, timer, sleep, [500], 1),
+    {badrpc, timeout} = gen_rpc:call(?NODE, timer, sleep, [500], 1),
     ok = timer:sleep(500).
 
 interleaved_call(_Config) ->
-    ok = ct:pal("Testing [interleaved_call]"),
     %% Spawn 3 consecutive processes that execute gen_rpc:call
     %% to the remote node and wait an inversely proportionate time
     %% for their result (effectively rendering the results out of order)
@@ -108,67 +121,53 @@ interleaved_call(_Config) ->
     ok.
 
 cast(_Config) ->
-    ok = ct:pal("Testing [cast]"),
-    true = gen_rpc:cast(?SLAVE, erlang, timestamp).
+    true = gen_rpc:cast(?NODE, erlang, timestamp).
 
 cast_anonymous_function(_Config) ->
-    ok = ct:pal("Testing [cast_anonymous_function]"),
-    true = gen_rpc:cast(?SLAVE, erlang, apply, [fun() -> os:timestamp() end, []]).
+    true = gen_rpc:cast(?NODE, erlang, apply, [fun() -> os:timestamp() end, []]).
 
 cast_mfa_undef(_Config) ->
-    ok = ct:pal("Testing [cast_mfa_undef]"),
-    true = gen_rpc:cast(?SLAVE, os, timestamp_undef, []).
+    true = gen_rpc:cast(?NODE, os, timestamp_undef, []).
 
 cast_mfa_exit(_Config) ->
-    ok = ct:pal("Testing [cast_mfa_exit]"),
-    true = gen_rpc:cast(?SLAVE, erlang, apply, [fun() -> exit(die) end, []]).
+    true = gen_rpc:cast(?NODE, erlang, apply, [fun() -> exit(die) end, []]).
 
 cast_mfa_throw(_Config) ->
-    ok = ct:pal("Testing [cast_mfa_throw]"),
-    true = gen_rpc:cast(?SLAVE, erlang, throw, ['throwme']).
+    true = gen_rpc:cast(?NODE, erlang, throw, ['throwme']).
 
 cast_inexistent_node(_Config) ->
-    ok = ct:pal("Testing [cast_inexistent_node]"),
     true = gen_rpc:cast(?FAKE_NODE, os, timestamp, [], 1000).
 
 safe_cast(_Config) ->
-    ok = ct:pal("Testing [safe_cast]"),
-    true = gen_rpc:safe_cast(?SLAVE, erlang, timestamp).
+    true = gen_rpc:safe_cast(?NODE, erlang, timestamp).
 
 safe_cast_anonymous_function(_Config) ->
-    ok = ct:pal("Testing [safe_cast_anonymous_function]"),
-    true = gen_rpc:safe_cast(?SLAVE, erlang, apply, [fun() -> os:timestamp() end, []]).
+    true = gen_rpc:safe_cast(?NODE, erlang, apply, [fun() -> os:timestamp() end, []]).
 
 safe_cast_mfa_undef(_Config) ->
-    ok = ct:pal("Testing [safe_cast_mfa_undef]"),
-    true = gen_rpc:safe_cast(?SLAVE, os, timestamp_undef, []).
+    true = gen_rpc:safe_cast(?NODE, os, timestamp_undef, []).
 
 safe_cast_mfa_exit(_Config) ->
-    ok = ct:pal("Testing [safe_cast_mfa_exit]"),
-    true = gen_rpc:safe_cast(?SLAVE, erlang, apply, [fun() -> exit(die) end, []]).
+    true = gen_rpc:safe_cast(?NODE, erlang, apply, [fun() -> exit(die) end, []]).
 
 safe_cast_mfa_throw(_Config) ->
-    ok = ct:pal("Testing [safe_cast_mfa_throw]"),
-    true = gen_rpc:safe_cast(?SLAVE, erlang, throw, ['throwme']).
+    true = gen_rpc:safe_cast(?NODE, erlang, throw, ['throwme']).
 
 safe_cast_inexistent_node(_Config) ->
-    ok = ct:pal("Testing [safe_cast_inexistent_node]"),
     {badrpc, nodedown} = gen_rpc:safe_cast(?FAKE_NODE, os, timestamp, [], 1000).
 
 async_call(_Config) ->
-    ok = ct:pal("Testing [async_call]"),
-    YieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    YieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
     {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
-    NbYieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
-    {value,{_,_,_}}= gen_rpc:nb_yield(NbYieldKey0, 10),
-    YieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [yield_key]),
+    NbYieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    {value, {_,_,_}} = gen_rpc:nb_yield(NbYieldKey0, 10),
+    YieldKey = gen_rpc:async_call(?NODE, io_lib, print, [yield_key]),
     "yield_key" = gen_rpc:yield(YieldKey),
-    NbYieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [nb_yield_key]),
-    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
+    NbYieldKey = gen_rpc:async_call(?NODE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 100).
 
 async_call_yield_reentrant(_Config) ->
-    ok = ct:pal("Testing [async_call_yield_reentrant]"),
-    YieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    YieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
     {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
     Self = self(),
     Pid = erlang:spawn(fun()->
@@ -182,68 +181,91 @@ async_call_yield_reentrant(_Config) ->
         5000 ->
             true = erlang:exit(Pid, brutal_kill)
     end,
-    NbYieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    NbYieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    {value, {_,_,_}} = gen_rpc:nb_yield(NbYieldKey0, 100),
     % Verify not able to reuse Key again. Key is one time use.
-    {_,_,_} = gen_rpc:yield(NbYieldKey0),
     timeout = gen_rpc:nb_yield(NbYieldKey0, 10),
-    YieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [yield_key]),
+    YieldKey = gen_rpc:async_call(?NODE, io_lib, print, [yield_key]),
     "yield_key" = gen_rpc:yield(YieldKey),
-    NbYieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [nb_yield_key]),
-    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
+    NbYieldKey = gen_rpc:async_call(?NODE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 100).
+
+async_call_anonymous_function(_Config) ->
+    YieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun(A) -> {self(), io_lib:print(A)} end,
+                                  [yield_key_anonymous_func]]),
+    {_, "yield_key_anonymous_func"} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
+                                    [nb_yield_key_anonymous_func]]),
+    {value, {_, "nb_yield_key_anonymous_func"}} = gen_rpc:nb_yield(NBYieldKey, 100).
+
+async_call_anonymous_undef(_Config) ->
+    YieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}} = gen_rpc:yield(YieldKey),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
+    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 100),
+    ok = ct:pal("Result [async_call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 async_call_mfa_undef(_Config) ->
-    ok = ct:pal("Testing [async_call_mfa_undef]"),
-    YieldKey = gen_rpc:async_call(?SLAVE, os, timestamp_undef),
+    YieldKey = gen_rpc:async_call(?NODE, os, timestamp_undef),
     {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?SLAVE, os, timestamp_undef),
-    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 20),
+    NBYieldKey = gen_rpc:async_call(?NODE, os, timestamp_undef),
+    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 100),
     ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 async_call_mfa_exit(_Config) ->
-    ok = ct:pal("Testing [async_call_mfa_exit]"),
-    YieldKey = gen_rpc:async_call(?SLAVE, erlang, exit, ['die']),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, exit, ['die']),
     {badrpc, {'EXIT', die}} = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?SLAVE, erlang, exit, ['die']),
-    {value, {badrpc, {'EXIT', die}}} = gen_rpc:nb_yield(NBYieldKey, 10),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, exit, ['die']),
+    {value, {badrpc, {'EXIT', die}}} = gen_rpc:nb_yield(NBYieldKey, 100),
     ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 async_call_mfa_throw(_Config) ->
-    ok = ct:pal("Testing [async_call_mfa_throw]"),
-    YieldKey = gen_rpc:async_call(?SLAVE, erlang, throw, ['throwXdown']),
+    YieldKey = gen_rpc:async_call(?NODE, erlang, throw, ['throwXdown']),
     'throwXdown' = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?SLAVE, erlang, throw, ['throwXdown']),
-    {value, 'throwXdown'} = gen_rpc:nb_yield(NBYieldKey, 10),
+    NBYieldKey = gen_rpc:async_call(?NODE, erlang, throw, ['throwXdown']),
+    {value, 'throwXdown'} = gen_rpc:nb_yield(NBYieldKey, 100),
     ok = ct:pal("Result [async_call_mfa_undef]: throw Reason={throwXdown}").
 
 async_call_yield_timeout(_Config) ->
-    ok = ct:pal("Testing [async_call_yield_timeout]"),
-    NBYieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    NBYieldKey = gen_rpc:async_call(?NODE, timer, sleep, [100]),
     timeout = gen_rpc:nb_yield(NBYieldKey, 5),
     ok = ct:pal("Result [async_call_yield_timeout]: signal=badrpc Reason={timeout}").
 
 async_call_nb_yield_infinity(_Config) ->
-    ok = ct:pal("Testing [async_call_yield_infinity]"),
-    YieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    YieldKey = gen_rpc:async_call(?NODE, timer, sleep, [100]),
     ok = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
+    NBYieldKey = gen_rpc:async_call(?NODE, timer, sleep, [100]),
     {value, ok} = gen_rpc:nb_yield(NBYieldKey, infinity),
     ok = ct:pal("Result [async_call_yield_infinity]: timer_sleep Result={ok}").
 
+async_call_inexistent_node(_Config) ->
+    YieldKey1 = gen_rpc:async_call(?FAKE_NODE, os, timestamp, []),
+    {badrpc, _} = gen_rpc:yield(YieldKey1),
+    YieldKey2 = gen_rpc:async_call(?FAKE_NODE, os, timestamp, []),
+    {value, {badrpc, _}} = gen_rpc:nb_yield(YieldKey2, 10000).
+
 client_inactivity_timeout(_Config) ->
-    ok = ct:pal("Testing [client_inactivity_timeout]"),
-    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp),
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?NODE, os, timestamp),
     ok = timer:sleep(600),
-    %% Lookup the client named process, shouldn't be undefined. Rewrite/Remove test?
-    undefined =:= whereis(?SLAVE).
+    %% Lookup the client named process, shouldn't be there
+    undefined = whereis(?NODE).
 
 server_inactivity_timeout(_Config) ->
-    ok = ct:pal("Testing [server_inactivity_timeout]"),
-    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp),
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?NODE, os, timestamp),
     ok = timer:sleep(600),
     %% Lookup the client named process, shouldn't be there
     [] = supervisor:which_children(gen_rpc_acceptor_sup),
     %% The server supervisor should have no children
     [] = supervisor:which_children(gen_rpc_server_sup).
+
+remote_node_call(_Config) ->
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp).
+
+compat_call(_Config) ->
+    {ok, _Port} = 'Elixir.ExRPC.Supervisor.Server':start_child(?NODE),
+    ServerProc = gen_rpc_helper:make_process_name(server, ?NODE),
+    ServerPid = whereis(ServerProc),
+    ok = gen_rpc_server_sup:stop_child(ServerPid).
 
 %%% ===================================================
 %%% Auxiliary functions for test cases
@@ -272,7 +294,7 @@ interleaved_call_loop(_, _, _, 3) ->
 %% We spawn it in order to achieve parallelism and test out-of-order
 %% execution of multiple RPC calls
 interleaved_call_proc(Caller, Num, Timeout) ->
-    Result = gen_rpc:call(?SLAVE, ?MODULE, interleaved_call_executor, [Num], Timeout),
+    Result = gen_rpc:call(?NODE, ?MODULE, interleaved_call_executor, [Num], Timeout),
     Caller ! {reply, self(), Num, Result},
     ok.
 

--- a/test/ct/multi_rpc_SUITE.erl
+++ b/test/ct/multi_rpc_SUITE.erl
@@ -4,7 +4,7 @@
 %%% Copyright 2015 Panagiotis Papadomitsos. All Rights Reserved.
 %%%
 
--module(multi_rpc_functional_SUITE).
+-module(multi_rpc_SUITE).
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% CT Macros
@@ -26,7 +26,6 @@ init_per_suite(Config) ->
     ok = gen_rpc_test_helper:set_application_environment(),
     %% Starting the application locally
     {ok, _MasterApps} = application:ensure_all_started(?APP),
-    ok = ct:pal("Started [multi_rpc_functional] suite with master node [~s]", [node()]),
     Config.
 
 end_per_suite(_Config) ->
@@ -47,7 +46,6 @@ end_per_testcase(_OtherTest, Config) ->
 %%% ===================================================
 %% Test main functions
 eval_everywhere_mfa_no_node(_Config) ->
-    ok = ct:pal("Testing [eval_everywhere_mfa_no_node]"),
     ConnectedNodes = [],
     abcast = gen_rpc:eval_everywhere(ConnectedNodes, erlang, whereis, [node()]),
     % Nothing catastrophically on sender side after sending call to the ether.
@@ -57,7 +55,7 @@ eval_everywhere_mfa_no_node(_Config) ->
 
 %% Eval_everywhere is fire and forget, which means some test cases need to show
 %% something has been executed on target nodes.
-%% The main technique used in eval_everywhere testing is to setup servers- slaves,
+%% The main technique used in eval_everywhere testing is to setup servers - slaves,
 %% and have the test script to ping the slaves with tagged messages and then wait for
 %% such and match the tags to verify originality.
 
@@ -65,20 +63,17 @@ eval_everywhere_mfa_no_node(_Config) ->
 %% tagged msg and its own identity.
 
 eval_everywhere_mfa_one_node(_Config) ->
-    ok = ct:pal("Testing [eval_everywhere_mfa_one_node]"),
     ConnectedNodes = [?SLAVE1],
     Msg = Name = 'evalmfa1',
     TestPid = self(),
     ok = terminate_process(Name),
     Pid = spawn_listener(?SLAVE1, Name, TestPid),
     true = register(Name, Pid),
-    ok = ct:pal("Testing [eval_everywhere_mfa_one_node] registered listening node"),
     abcast = gen_rpc:eval_everywhere(ConnectedNodes, 'gen_rpc_test_helper', ping, [{?NODE, Name, Msg}]),
     {ok, passed} = wait_for_reply(?SLAVE1),
     ok.
 
 eval_everywhere_mfa_multiple_nodes(_Config) ->
-    ok = ct:pal("Testing [eval_everywhere_mfa_multiple_nodes]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2],
     Msg = Name = 'evalmfamulti',
     TestPid = self(),
@@ -90,7 +85,6 @@ eval_everywhere_mfa_multiple_nodes(_Config) ->
     ok.
 
 eval_everywhere_mfa_multiple_nodes_timeout(_Config) ->
-    ok = ct:pal("Testing [eval_everywhere_mfa_multiple_nodes_timeout]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2],
     Msg = Name = 'evalmfamultito',
     TestPid = self(),
@@ -102,7 +96,6 @@ eval_everywhere_mfa_multiple_nodes_timeout(_Config) ->
     ok.
 
 eval_everywhere_mfa_exit_multiple_nodes(_Config) ->
-    ok = ct:pal("Testing [eval_everywhere_mfa_exit_multiple_nodes]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2],
     abcast = gen_rpc:eval_everywhere(ConnectedNodes, erlang, exit, [fatal]),
     % Nothing blows up on sender side after sending call to nothing
@@ -111,19 +104,16 @@ eval_everywhere_mfa_exit_multiple_nodes(_Config) ->
     true = erlang:is_process_alive(whereis(gen_rpc_client_sup)).
 
 eval_everywhere_mfa_throw_multiple_nodes(_Config) ->
-    ok = ct:pal("Testing [eval_everywhere_mfa_throw_multiple_nodes]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2],
     abcast = gen_rpc:eval_everywhere(ConnectedNodes, erlang, throw, ['throwXup']),
     ok = ct:pal("[erlang:throw only]. Verify the crash log from ct. You should see {{nocatch,throwXup}, ....} on the target node").
 
 eval_everywhere_mfa_timeout_multiple_nodes(_Config) ->
-    ok = ct:pal("Testing [eval_everywhere_mfa_timeout_multiple_nodes]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2],
     abcast = gen_rpc:eval_everywhere(ConnectedNodes, erlang, throw, ['throwXup']),
     ok = ct:pal("[erlang:throw only]. Verify the crash log from ct. You should see {{nocatch,throwXup}, ....} on the target node").
 
 safe_eval_everywhere_mfa_no_node(_Config) ->
-    ok = ct:pal("Testing [safe_eval_everywhere_mfa_no_node]"),
     ConnectedNodes = [],
     [] = gen_rpc:safe_eval_everywhere(ConnectedNodes, erlang, whereis, [node()]),
     % Nothing catastrophically blows up  on sender side after sending call to the ether.
@@ -132,20 +122,17 @@ safe_eval_everywhere_mfa_no_node(_Config) ->
     true = erlang:is_process_alive(whereis(gen_rpc_client_sup)).
 
 safe_eval_everywhere_mfa_one_node(_Config) ->
-    ok = ct:pal("Testing [safe_eval_everywhere_mfa_one_node]"),
     ConnectedNodes = [?SLAVE1],
     Msg = Name = 'safeevalmfa1',
     TestPid = self(),
     ok = terminate_process(Name),
     Pid = spawn_listener(?SLAVE1, Name, TestPid),
     true = register(Name, Pid),
-    ok = ct:pal("Testing [safe_eval_everywhere_mfa_one_node] Registered Listening Node"),
     [true, []] = gen_rpc:safe_eval_everywhere(ConnectedNodes, 'gen_rpc_test_helper', ping, [{?NODE, Name, Msg}]),
     {ok, passed} = wait_for_reply(?SLAVE1),
     ok.
 
 safe_eval_everywhere_mfa_multiple_nodes(_Config) ->
-    ok = ct:pal("Testing [safe_eval_everywhere_mfa_multiple_nodes]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2, ?FAKE_NODE],
     Msg = Name = 'safeevalmfamulti',
     TestPid = self(),
@@ -157,7 +144,6 @@ safe_eval_everywhere_mfa_multiple_nodes(_Config) ->
     ok.
 
 safe_eval_everywhere_mfa_multiple_nodes_timeout(_Config) ->
-    ok = ct:pal("Testing [safe_eval_everywhere_mfa_multiple_nodes_timeout]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2],
     Msg = Name = 'safeevalmfamultiTO',
     TestPid = self(),
@@ -169,7 +155,6 @@ safe_eval_everywhere_mfa_multiple_nodes_timeout(_Config) ->
     ok.
 
 safe_eval_everywhere_mfa_exit_multiple_nodes(_Config) ->
-    ok = ct:pal("Testing [safe_eval_everywhere_mfa_exit_multiple_nodes]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2],
     [true, []] = gen_rpc:safe_eval_everywhere(ConnectedNodes, erlang, exit, [fatal]),
     % Nothing blows up on sender side after sending call to the ether
@@ -178,16 +163,54 @@ safe_eval_everywhere_mfa_exit_multiple_nodes(_Config) ->
     true = erlang:is_process_alive(whereis(gen_rpc_client_sup)).
 
 safe_eval_everywhere_mfa_throw_multiple_nodes(_Config) ->
-    ok = ct:pal("Testing [safe_eval_everywhere_mfa_throw_multiple_nodes]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2],
     [true, []] = gen_rpc:safe_eval_everywhere(ConnectedNodes, erlang, throw, ['throwXup']),
     ok = ct:pal("[erlang:throw only]. Verify the crash log from ct. You should see {{nocatch,throwXup}, ....} on the target node").
 
 safe_eval_everywhere_mfa_timeout_multiple_nodes(_Config) ->
-    ok = ct:pal("Testing [eval_everywhere_mfa_timeout_multiple_nodes]"),
     ConnectedNodes = [?SLAVE1, ?SLAVE2],
     [true, []] = gen_rpc:safe_eval_everywhere(ConnectedNodes, erlang, throw, ['throwXup']),
     ok = ct:pal("erlang:throw only]. Verify the crash log from ct. You should see {{nocatch,throwXup}, ....} on the target node").
+
+multicall_local_node(_Config) ->
+    {[{_,_,_}], []} = gen_rpc:multicall(os, timestamp, []),
+    %% Nodes should not include us
+    false = lists:member(node(), gen_rpc:nodes()).
+
+multicall_multiple_nodes(_Config) ->
+    ConnectedNodes = [?SLAVE1, ?SLAVE2],
+    {[{_,_,_}, {_,_,_}], []} = gen_rpc:multicall(ConnectedNodes, os, timestamp, []),
+    Nodes = gen_rpc:nodes(),
+    true = lists:member(?SLAVE1, Nodes),
+    true = lists:member(?SLAVE2, Nodes).
+
+multicall_multiple_nodes_and_local(_Config) ->
+    ConnectedNodes = [?SLAVE1, ?SLAVE2],
+    {[{_,_,_}, {_,_,_}], []} = gen_rpc:multicall(ConnectedNodes, os, timestamp, []),
+    {[{_,_,_}, {_,_,_}, {_,_,_}], []} = gen_rpc:multicall(os, timestamp, []),
+    Nodes = gen_rpc:nodes(),
+    true = lists:member(?SLAVE1, Nodes),
+    true = lists:member(?SLAVE2, Nodes).
+
+multicall_multiple_nodes_with_timeout(_Config) ->
+    ConnectedNodes = [?SLAVE1, ?SLAVE2],
+    {[{_,_,_}, {_,_,_}], []} = gen_rpc:multicall(ConnectedNodes, os, timestamp, [], 5000),
+    Nodes = gen_rpc:nodes(),
+    true = lists:member(?SLAVE1, Nodes),
+    true = lists:member(?SLAVE2, Nodes),
+    {[], BadNodes} = gen_rpc:multicall(ConnectedNodes, timer, sleep, [500], 100),
+    true = lists:member(?SLAVE1, BadNodes),
+    true = lists:member(?SLAVE2, BadNodes).
+
+multicall_multiple_nodes_with_bad_node(_Config) ->
+    ConnectedNodes = [?SLAVE1, ?SLAVE2, ?FAKE_NODE],
+    {Results, BadNodes} = gen_rpc:multicall(ConnectedNodes, os, timestamp, [], 10000),
+    2 = length(Results),
+    [?FAKE_NODE] = BadNodes,
+    Nodes = gen_rpc:nodes(),
+    true = lists:member(?SLAVE1, Nodes),
+    true = lists:member(?SLAVE2, Nodes),
+    false = lists:member(?FAKE_NODE, Nodes).
 
 %%% ===================================================
 %%% Auxiliary functions for test cases

--- a/test/ct/remote_SUITE.erl
+++ b/test/ct/remote_SUITE.erl
@@ -4,7 +4,7 @@
 %%% Copyright 2015 Panagiotis Papadomitsos. All Rights Reserved.
 %%%
 
--module(local_functional_SUITE).
+-module(remote_SUITE).
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% CT Macros
@@ -26,96 +26,73 @@ init_per_suite(Config) ->
     ok = gen_rpc_test_helper:set_application_environment(),
     %% Starting the application locally
     {ok, _MasterApps} = application:ensure_all_started(?APP),
-    ok = ct:pal("Started [local_functional] suite with master node [~s]", [node()]),
+    ok = ct:pal("Started [remote_functional] suite with master node [~s]", [node()]),
     Config.
 
 end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(client_inactivity_timeout, Config) ->
-    ok = gen_rpc_test_helper:restart_application(),
-    ok = gen_rpc_test_helper:set_application_environment(),
-    ok = application:set_env(?APP, client_inactivity_timeout, 500),
-    Config;
-
-init_per_testcase(server_inactivity_timeout, Config) ->
-    ok = gen_rpc_test_helper:restart_application(),
-    ok = gen_rpc_test_helper:set_application_environment(),
-    ok = application:set_env(?APP, server_inactivity_timeout, 500),
-    Config;
-
-init_per_testcase(async_call_inexistent_node, Config) ->
-    ok = gen_rpc_test_helper:restart_application(),
-    ok = gen_rpc_test_helper:set_application_environment(),
-    Config;
-
-init_per_testcase(remote_node_call, Config) ->
     ok = gen_rpc_test_helper:start_slave(?SLAVE),
-    Config;
-
-init_per_testcase(_OtherTest, Config) ->
-    Config.
-
-end_per_testcase(client_inactivity_timeout, Config) ->
+    ok = gen_rpc_test_helper:restart_application(),
+    ok = gen_rpc_test_helper:set_application_environment(),
     ok = application:set_env(?APP, client_inactivity_timeout, infinity),
     Config;
 
-end_per_testcase(server_inactivity_timeout, Config) ->
+init_per_testcase(server_inactivity_timeout, Config) ->
+    ok = gen_rpc_test_helper:start_slave(?SLAVE),
+    ok = gen_rpc_test_helper:restart_application(),
+    ok = gen_rpc_test_helper:set_application_environment(),
     ok = application:set_env(?APP, server_inactivity_timeout, infinity),
     Config;
 
-end_per_testcase(remote_node_call, Config) ->
+init_per_testcase(_OtherTest, Config) ->
+    ok = gen_rpc_test_helper:start_slave(?SLAVE),
+    Config.
+
+end_per_testcase(client_inactivity_timeout, Config) ->
     ok = gen_rpc_test_helper:stop_slave(?SLAVE),
+    ok = gen_rpc_test_helper:restart_application(),
+    ok = gen_rpc_test_helper:set_application_environment(),
+    Config;
+
+end_per_testcase(server_inactivity_timeout, Config) ->
+    ok = gen_rpc_test_helper:stop_slave(?SLAVE),
+    ok = gen_rpc_test_helper:restart_application(),
+    ok = gen_rpc_test_helper:set_application_environment(),
     Config;
 
 end_per_testcase(_OtherTest, Config) ->
+    ok = gen_rpc_test_helper:stop_slave(?SLAVE),
     Config.
+
 
 %%% ===================================================
 %%% Test cases
 %%% ===================================================
-%% Test supervisor's status
-supervisor_black_box(_Config) ->
-    ok = ct:pal("Testing [supervisor_black_box]"),
-    true = erlang:is_process_alive(whereis(gen_rpc_server_sup)),
-    true = erlang:is_process_alive(whereis(gen_rpc_acceptor_sup)),
-    true = erlang:is_process_alive(whereis(gen_rpc_client_sup)),
-    ok.
-
 %% Test main functions
 call(_Config) ->
     ok = ct:pal("Testing [call]"),
-    {_Mega, _Sec, _Micro} = gen_rpc:call(?NODE, os, timestamp).
-
-call_anonymous_function(_Config) ->
-    ok = ct:pal("Testing [call_anonymous_function]"),
-    {_,"\"call_anonymous_function\""} = gen_rpc:call(?NODE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
-                                                     ["call_anonymous_function"]]).
-
-call_anonymous_undef(_Config) ->
-    ok = ct:pal("Testing [call_anonymous_undef]"),
-    ok = ct:pal("Testing [call_anonymous_undef] assuming stackstack depth of 5"),
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}}  = gen_rpc:call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
-   ok = ct:pal("Result [call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp).
 
 call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [call_mfa_undef]"),
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?NODE, os, timestamp_undef),
+    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:call(?SLAVE, os, timestamp_undef),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 call_mfa_exit(_Config) ->
     ok = ct:pal("Testing [call_mfa_exit]"),
-    {badrpc, {'EXIT', die}} = gen_rpc:call(?NODE, erlang, exit, ['die']),
+    {badrpc, {'EXIT', die}} = gen_rpc:call(?SLAVE, erlang, exit, ['die']),
     ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
 
 call_mfa_throw(_Config) ->
     ok = ct:pal("Testing [call_mfa_throw]"),
-    'throwXdown' = gen_rpc:call(?NODE, erlang, throw, ['throwXdown']),
-    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={throwXdown}").
+    'throwXdown' = gen_rpc:call(?SLAVE, erlang, throw, ['throwXdown']),
+    ok = ct:pal("Result [call_mfa_undef]: signal=EXIT Reason={die}").
 
 call_with_receive_timeout(_Config) ->
     ok = ct:pal("Testing [call_with_receive_timeout]"),
-    {badrpc, timeout} = gen_rpc:call(?NODE, timer, sleep, [500], 1),
+    {badrpc, timeout} = gen_rpc:call(?SLAVE, timer, sleep, [500], 1),
     ok = timer:sleep(500).
 
 interleaved_call(_Config) ->
@@ -132,23 +109,23 @@ interleaved_call(_Config) ->
 
 cast(_Config) ->
     ok = ct:pal("Testing [cast]"),
-    true = gen_rpc:cast(?NODE, erlang, timestamp).
+    true = gen_rpc:cast(?SLAVE, erlang, timestamp).
 
 cast_anonymous_function(_Config) ->
     ok = ct:pal("Testing [cast_anonymous_function]"),
-    true = gen_rpc:cast(?NODE, erlang, apply, [fun() -> os:timestamp() end, []]).
+    true = gen_rpc:cast(?SLAVE, erlang, apply, [fun() -> os:timestamp() end, []]).
 
 cast_mfa_undef(_Config) ->
     ok = ct:pal("Testing [cast_mfa_undef]"),
-    true = gen_rpc:cast(?NODE, os, timestamp_undef, []).
+    true = gen_rpc:cast(?SLAVE, os, timestamp_undef, []).
 
 cast_mfa_exit(_Config) ->
     ok = ct:pal("Testing [cast_mfa_exit]"),
-    true = gen_rpc:cast(?NODE, erlang, apply, [fun() -> exit(die) end, []]).
+    true = gen_rpc:cast(?SLAVE, erlang, apply, [fun() -> exit(die) end, []]).
 
 cast_mfa_throw(_Config) ->
     ok = ct:pal("Testing [cast_mfa_throw]"),
-    true = gen_rpc:cast(?NODE, erlang, throw, ['throwme']).
+    true = gen_rpc:cast(?SLAVE, erlang, throw, ['throwme']).
 
 cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [cast_inexistent_node]"),
@@ -156,23 +133,23 @@ cast_inexistent_node(_Config) ->
 
 safe_cast(_Config) ->
     ok = ct:pal("Testing [safe_cast]"),
-    true = gen_rpc:safe_cast(?NODE, erlang, timestamp).
+    true = gen_rpc:safe_cast(?SLAVE, erlang, timestamp).
 
 safe_cast_anonymous_function(_Config) ->
     ok = ct:pal("Testing [safe_cast_anonymous_function]"),
-    true = gen_rpc:safe_cast(?NODE, erlang, apply, [fun() -> os:timestamp() end, []]).
+    true = gen_rpc:safe_cast(?SLAVE, erlang, apply, [fun() -> os:timestamp() end, []]).
 
 safe_cast_mfa_undef(_Config) ->
     ok = ct:pal("Testing [safe_cast_mfa_undef]"),
-    true = gen_rpc:safe_cast(?NODE, os, timestamp_undef, []).
+    true = gen_rpc:safe_cast(?SLAVE, os, timestamp_undef, []).
 
 safe_cast_mfa_exit(_Config) ->
     ok = ct:pal("Testing [safe_cast_mfa_exit]"),
-    true = gen_rpc:safe_cast(?NODE, erlang, apply, [fun() -> exit(die) end, []]).
+    true = gen_rpc:safe_cast(?SLAVE, erlang, apply, [fun() -> exit(die) end, []]).
 
 safe_cast_mfa_throw(_Config) ->
     ok = ct:pal("Testing [safe_cast_mfa_throw]"),
-    true = gen_rpc:safe_cast(?NODE, erlang, throw, ['throwme']).
+    true = gen_rpc:safe_cast(?SLAVE, erlang, throw, ['throwme']).
 
 safe_cast_inexistent_node(_Config) ->
     ok = ct:pal("Testing [safe_cast_inexistent_node]"),
@@ -180,18 +157,18 @@ safe_cast_inexistent_node(_Config) ->
 
 async_call(_Config) ->
     ok = ct:pal("Testing [async_call]"),
-    YieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    YieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
     {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
-    NbYieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
-    {value, {_,_,_}}= gen_rpc:nb_yield(NbYieldKey0, 100),
-    YieldKey = gen_rpc:async_call(?NODE, io_lib, print, [yield_key]),
+    NbYieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
+    {value,{_,_,_}}= gen_rpc:nb_yield(NbYieldKey0, 10),
+    YieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [yield_key]),
     "yield_key" = gen_rpc:yield(YieldKey),
-    NbYieldKey = gen_rpc:async_call(?NODE, io_lib, print, [nb_yield_key]),
-    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 100).
+    NbYieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
 
 async_call_yield_reentrant(_Config) ->
     ok = ct:pal("Testing [async_call_yield_reentrant]"),
-    YieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
+    YieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
     {_Mega, _Sec, _Micro} = gen_rpc:yield(YieldKey0),
     Self = self(),
     Pid = erlang:spawn(fun()->
@@ -205,103 +182,68 @@ async_call_yield_reentrant(_Config) ->
         5000 ->
             true = erlang:exit(Pid, brutal_kill)
     end,
-    NbYieldKey0 = gen_rpc:async_call(?NODE, os, timestamp, []),
-    {value, {_,_,_}} = gen_rpc:nb_yield(NbYieldKey0, 100),
+    NbYieldKey0 = gen_rpc:async_call(?SLAVE, os, timestamp, []),
     % Verify not able to reuse Key again. Key is one time use.
+    {_,_,_} = gen_rpc:yield(NbYieldKey0),
     timeout = gen_rpc:nb_yield(NbYieldKey0, 10),
-    YieldKey = gen_rpc:async_call(?NODE, io_lib, print, [yield_key]),
+    YieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [yield_key]),
     "yield_key" = gen_rpc:yield(YieldKey),
-    NbYieldKey = gen_rpc:async_call(?NODE, io_lib, print, [nb_yield_key]),
-    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 100).
-
-async_call_anonymous_function(_Config) ->
-    ok = ct:pal("Testing [async_call_anonymous_function]"),
-    YieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun(A) -> {self(), io_lib:print(A)} end,
-                                  [yield_key_anonymous_func]]),
-    {_, "yield_key_anonymous_func"} = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?NODE, erlang, apply,[fun(A) -> {self(), io_lib:print(A)} end,
-                                    [nb_yield_key_anonymous_func]]),
-    {value, {_, "nb_yield_key_anonymous_func"}} = gen_rpc:nb_yield(NBYieldKey, 100).
-
-async_call_anonymous_undef(_Config) ->
-    ok = ct:pal("Testing [async_call_anonymous_undef]"),
-    YieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
-    {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}} = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?NODE, erlang, apply, [fun() -> os:timestamp_undef() end, []]),
-    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,[],[]},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 100),
-    ok = ct:pal("Result [async_call_anonymous_undef]: signal=EXIT Reason={os,timestamp_undef}").
+    NbYieldKey = gen_rpc:async_call(?SLAVE, io_lib, print, [nb_yield_key]),
+    {value, "nb_yield_key"} = gen_rpc:nb_yield(NbYieldKey, 10).
 
 async_call_mfa_undef(_Config) ->
     ok = ct:pal("Testing [async_call_mfa_undef]"),
-    YieldKey = gen_rpc:async_call(?NODE, os, timestamp_undef),
+    YieldKey = gen_rpc:async_call(?SLAVE, os, timestamp_undef),
     {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}} = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?NODE, os, timestamp_undef),
-    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 100),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, os, timestamp_undef),
+    {value, {badrpc, {'EXIT', {undef,[{os,timestamp_undef,_,_},_]}}}} = gen_rpc:nb_yield(NBYieldKey, 20),
     ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 async_call_mfa_exit(_Config) ->
     ok = ct:pal("Testing [async_call_mfa_exit]"),
-    YieldKey = gen_rpc:async_call(?NODE, erlang, exit, ['die']),
+    YieldKey = gen_rpc:async_call(?SLAVE, erlang, exit, ['die']),
     {badrpc, {'EXIT', die}} = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?NODE, erlang, exit, ['die']),
-    {value, {badrpc, {'EXIT', die}}} = gen_rpc:nb_yield(NBYieldKey, 100),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, erlang, exit, ['die']),
+    {value, {badrpc, {'EXIT', die}}} = gen_rpc:nb_yield(NBYieldKey, 10),
     ok = ct:pal("Result [async_call_mfa_undef]: signal=EXIT Reason={os,timestamp_undef}").
 
 async_call_mfa_throw(_Config) ->
     ok = ct:pal("Testing [async_call_mfa_throw]"),
-    YieldKey = gen_rpc:async_call(?NODE, erlang, throw, ['throwXdown']),
+    YieldKey = gen_rpc:async_call(?SLAVE, erlang, throw, ['throwXdown']),
     'throwXdown' = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?NODE, erlang, throw, ['throwXdown']),
-    {value, 'throwXdown'} = gen_rpc:nb_yield(NBYieldKey, 100),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, erlang, throw, ['throwXdown']),
+    {value, 'throwXdown'} = gen_rpc:nb_yield(NBYieldKey, 10),
     ok = ct:pal("Result [async_call_mfa_undef]: throw Reason={throwXdown}").
 
 async_call_yield_timeout(_Config) ->
     ok = ct:pal("Testing [async_call_yield_timeout]"),
-    NBYieldKey = gen_rpc:async_call(?NODE, timer, sleep, [100]),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
     timeout = gen_rpc:nb_yield(NBYieldKey, 5),
     ok = ct:pal("Result [async_call_yield_timeout]: signal=badrpc Reason={timeout}").
 
 async_call_nb_yield_infinity(_Config) ->
     ok = ct:pal("Testing [async_call_yield_infinity]"),
-    YieldKey = gen_rpc:async_call(?NODE, timer, sleep, [100]),
+    YieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
     ok = gen_rpc:yield(YieldKey),
-    NBYieldKey = gen_rpc:async_call(?NODE, timer, sleep, [100]),
+    NBYieldKey = gen_rpc:async_call(?SLAVE, timer, sleep, [1000]),
     {value, ok} = gen_rpc:nb_yield(NBYieldKey, infinity),
     ok = ct:pal("Result [async_call_yield_infinity]: timer_sleep Result={ok}").
 
-async_call_inexistent_node(_Config) ->
-    ok = ct:pal("Testing [async_call_inexistent_node]"),
-    YieldKey1 = gen_rpc:async_call(?FAKE_NODE, os, timestamp, []),
-    {badrpc, _} = gen_rpc:yield(YieldKey1),
-    YieldKey2 = gen_rpc:async_call(?FAKE_NODE, os, timestamp, []),
-    {value, {badrpc, _}} = gen_rpc:nb_yield(YieldKey2, 10000).
-
 client_inactivity_timeout(_Config) ->
     ok = ct:pal("Testing [client_inactivity_timeout]"),
-    {_Mega, _Sec, _Micro} = gen_rpc:call(?NODE, os, timestamp),
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp),
     ok = timer:sleep(600),
-    %% Lookup the client named process, shouldn't be there
-    undefined = whereis(?NODE).
+    %% Lookup the client named process, shouldn't be undefined. Rewrite/Remove test?
+    undefined =:= whereis(?SLAVE).
 
 server_inactivity_timeout(_Config) ->
     ok = ct:pal("Testing [server_inactivity_timeout]"),
-    {_Mega, _Sec, _Micro} = gen_rpc:call(?NODE, os, timestamp),
+    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp),
     ok = timer:sleep(600),
     %% Lookup the client named process, shouldn't be there
     [] = supervisor:which_children(gen_rpc_acceptor_sup),
     %% The server supervisor should have no children
     [] = supervisor:which_children(gen_rpc_server_sup).
-
-remote_node_call(_Config) ->
-    ok = ct:pal("Testing [remote_node_call]"),
-    {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp).
-
-compat_call(_Config) ->
-    ok = ct:pal("Testing [compat_call]"),
-    {ok, _Port} = 'Elixir.ExRPC.Supervisor.Server':start_child(?NODE),
-    ServerProc = gen_rpc_helper:make_process_name(server, ?NODE),
-    ServerPid = whereis(ServerProc),
-    ok = gen_rpc_server_sup:stop_child(ServerPid).
 
 %%% ===================================================
 %%% Auxiliary functions for test cases
@@ -330,7 +272,7 @@ interleaved_call_loop(_, _, _, 3) ->
 %% We spawn it in order to achieve parallelism and test out-of-order
 %% execution of multiple RPC calls
 interleaved_call_proc(Caller, Num, Timeout) ->
-    Result = gen_rpc:call(?NODE, ?MODULE, interleaved_call_executor, [Num], Timeout),
+    Result = gen_rpc:call(?SLAVE, ?MODULE, interleaved_call_executor, [Num], Timeout),
     Caller ! {reply, self(), Num, Result},
     ok.
 

--- a/test/gen_rpc_test_helper.erl
+++ b/test/gen_rpc_test_helper.erl
@@ -74,12 +74,20 @@ get_test_functions(Module) ->
     [FName || {FName, _} <- lists:filter(
                                fun ({module_info,_}) -> false;
                                    ({all,_}) -> false;
-                                   ({init_per_suite,1}) -> false;
-                                   ({end_per_suite,1}) -> false;
-                                   ({interleaved_call_proc,3}) -> false;
-                                   ({wait_for_reply,1}) -> false;
-                                   ({terminate_process,1}) -> false;
-                                   ({interleaved_call_executor,1}) -> false;
+                                   %% Local tests
+                                   ({init_per_suite,_}) -> false;
+                                   ({end_per_suite,_}) -> false;
+                                   ({interleaved_call_proc,_}) -> false;
+                                   ({interleaved_call_executor,_}) -> false;
+                                   ({interleaved_call_loop,_}) -> false;
+                                   %% Multi RPC
+                                   ({spawn_listener,_}) -> false;
+                                   ({spawn_listener2,_}) -> false;
+                                   ({loop1,_}) -> false;
+                                   ({loop2,_}) -> false;
+                                   ({wait_for_reply,_}) -> false;
+                                   ({terminate_process,_}) -> false;
+                                   %% Else
                                    ({_,1}) -> true;
                                    ({_,_}) -> false
                                end, Functions)].

--- a/test/include/ct.hrl
+++ b/test/include/ct.hrl
@@ -23,7 +23,8 @@
         {lager, colored, true},
         {lager, handlers, [
             {lager_file_backend, [{file, "messages.log"}, {level, info}, {formatter, lager_default_formatter}, {size, 0}, {date, "$D0"}, {count, 7},
-                {formatter_config, ["[", date, " ", time, "] severity=", severity, " module=", {module, "gen_rpc"}, " pid=\"", pid, "\" ", message, "\n"]}
+                {formatter_config, ["[", date, " ", time, "] severity=", severity, " node=\"", {node, "undefined"}, "\" pid=\"", pid,
+                    "\" module=", {module, "gen_rpc"}, " function=", {function, "undefined"}, " ", message, "\n"]}
             ]}
         ]}
 ]).


### PR DESCRIPTION
- Refactor async_call to work with timeouts and better process messaging
- Implement multicall per the rpc:multicall specs
- Implement gen_rpc:nodes/0 per erlang:nodes/0
- Improve the build system in various places
- Bump lager version
- Add sync library for local development