### PR TITLE
adjust paths in the ct coverspec to include/exclude the appropriate directories in _build

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -55,11 +55,6 @@
     ]}
 ]}.
 
-%% Code coverage
-{cover_enabled, true}.
-{cover_export_enabled, true}.
-{cover_opts, [verbose]}.
-
 %% Coveralls code coverage reporting
 {coveralls_coverdata, "_build/test/cover/ct.coverdata"}.
 {coveralls_service_name, "travis-ci"}.

--- a/test/gen_rpc.coverspec
+++ b/test/gen_rpc.coverspec
@@ -1,5 +1,5 @@
 {nodes, ['gen_rpc_master@127.0.0.1', 'gen_rpc_slave1@127.0.0.1', 'gen_rpc_slave2@127.0.0.1', 'nonode@nohost']}.
 {export, "../_build/test/cover/ct.coverdata"}.
 {level, details}.
-{incl_dirs_r, ["../src"]}.
-{excl_dirs_r, ["../test"]}.
+{incl_dirs_r, ["../_build/test/lib/gen_rpc/src", "../_build/test/lib/gen_rpc/ebin"]}.
+{excl_dirs_r, ["../_build/test/lib/gen_rpc/test"]}.


### PR DESCRIPTION
i noticed you are also using distributed ct which rebar3 doesn't support (rebar3 currently has no way to start up other nodes) but the test suite completes ok despite this so i left it unaltered