### PR TITLE
Stop gen_rpc_server after connection is accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gen_rpc: A scalable RPC library for Erlang-VM based languages.
+# gen_rpc: A scalable RPC library for Erlang-VM based languages
 
 ## Overview
 
@@ -7,6 +7,7 @@
 - Branch status (`develop`): [![Build Status](https://travis-ci.org/priestjim/gen_rpc.svg?branch=develop)](https://travis-ci.org/priestjim/gen_rpc) [![Coverage Status](https://coveralls.io/repos/priestjim/gen_rpc/badge.svg?branch=develop&service=github)](https://coveralls.io/github/priestjim/gen_rpc?branch=develop)
 - Issues: [![GitHub issues](https://img.shields.io/github/issues/priestjim/gen_rpc.svg)](https://github.com/priestjim/gen_rpc/issues)
 - License: [![GitHub license](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/priestjim/gen_rpc/master/LICENSE)
+- [Erlang Factory 2016 Talk](https://www.youtube.com/watch?feature=player_embedded&v=xiPnLACtNeo)
 
 ## Rationale
 

--- a/include/app.hrl
+++ b/include/app.hrl
@@ -9,9 +9,10 @@
 %%% Default TCP options
 -define(DEFAULT_TCP_OPTS, [binary,
         {packet,4},
+        {exit_on_close,true},
         {nodelay,true}, % Send our requests immediately
         {send_timeout_close,true}, % When the socket times out, close the connection
-        {delay_send,true}, % Scheduler should favor big batch requests
+        {delay_send,false}, % Scheduler should favor timely delivery
         {linger,{true,2}}, % Allow the socket to flush outgoing data for 2" before closing it - useful for casts
         {reuseaddr,true}, % Reuse local port numbers
         {keepalive,true}, % Keep our channel open
@@ -21,6 +22,7 @@
 %%% Default TCP options
 -define(ACCEPTOR_DEFAULT_TCP_OPTS, [binary,
         {packet,4},
+        {exit_on_close,true},
         {active,once}]). % Retrieve data from socket upon request
 
 %%% The TCP options that should be copied from the listener to the acceptor

--- a/src/gen_rpc_dispatcher.erl
+++ b/src/gen_rpc_dispatcher.erl
@@ -44,7 +44,6 @@ start_client(Node) when is_atom(Node) ->
 %%% ===================================================
 init([]) ->
     ok = lager:info("event=start"),
-    _OldVal = process_flag(trap_exit, true),
     {ok, undefined}.
 
 %% Simply launch a connection to a node through the appropriate
@@ -83,6 +82,5 @@ handle_info(Msg, undefined) ->
 code_change(_OldVersion, undefined, _Extra) ->
     {ok, undefined}.
 
-terminate(Reason, undefined) ->
-    ok = lager:debug("reason=\"~512tp\"", [Reason]),
+terminate(_Reason, undefined) ->
     ok.

--- a/src/gen_rpc_tcp_acceptor.erl
+++ b/src/gen_rpc_tcp_acceptor.erl
@@ -148,10 +148,5 @@ handle_info(Msg, StateName, State) ->
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 
-%% Terminate normally if we haven't received the socket yet
-terminate(_Reason, _StateName, #state{socket=undefined}) ->
-    ok;
-%% Terminate by closing the socket
-terminate(_Reason, _StateName, #state{socket=Socket}) ->
-    ok = lager:debug("socket=\"~p\"", [Socket]),
+terminate(_Reason, _StateName, _State) ->
     ok.

--- a/src/gen_rpc_tcp_server.erl
+++ b/src/gen_rpc_tcp_server.erl
@@ -105,8 +105,7 @@ handle_info(Msg, State) ->
     {stop, {unknown_message, Msg}, State}.
 
 %% Terminate cleanly by closing the listening socket
-terminate(_Reason, #state{socket=Socket}) ->
-    ok = lager:debug("socket=\"~p\"", [Socket]),
+terminate(_Reason, _Socket) ->
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/supervisor/gen_rpc_tcp_acceptor_sup.erl
+++ b/src/supervisor/gen_rpc_tcp_acceptor_sup.erl
@@ -48,6 +48,6 @@ stop_child(Pid) when is_pid(Pid) ->
 %%% Supervisor callbacks
 %%% ===================================================
 init([]) ->
-    {ok, {{simple_one_for_one, 100, 1}, [
+    {ok, {{simple_one_for_one, 1000, 1}, [
         {gen_rpc_tcp_acceptor, {gen_rpc_tcp_acceptor,start_link,[]}, temporary, 5000, worker, [gen_rpc_tcp_acceptor]}
     ]}}.

--- a/test/ct/integration_SUITE.erl
+++ b/test/ct/integration_SUITE.erl
@@ -62,3 +62,14 @@ multicall(_Config) ->
     RespLen = length(RespList),
     PeersLen = AliveLen,
     RespLen = AliveLen + 1.
+
+remote_socket_close(_Config) ->
+    Peers = peers(),
+    ok = lists:foreach(fun(Node) ->
+        [{_,AccPid,_,_}] = rpc:call(Node, supervisor, which_children, [gen_rpc_acceptor_sup]),
+        true = rpc:call(Node, erlang, exit, [AccPid,kill])
+    end, peers()),
+    Alive = gen_rpc:nodes(),
+    ok = lists:foreach(fun(Node) ->
+        false = lists:member(Node, Alive)
+    end, Peers).

--- a/test/ct/remote_SUITE.erl
+++ b/test/ct/remote_SUITE.erl
@@ -212,10 +212,8 @@ random_local_tcp_close(_Config) ->
 
 random_remote_tcp_close(_Config) ->
     {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp),
-    [{_,ServerPid,_,_}] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_server_sup]),
-    {_, Socket, _, _, _} = rpc:call(?SLAVE, sys, get_state, [ServerPid]),
-    ok = rpc:call(?SLAVE, gen_tcp, close, [Socket]),
-    ok = timer:sleep(100), % Give some time to the supervisor to kill the children
+    [{_,AccPid,_,_}] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_acceptor_sup]),
+    true = rpc:call(?SLAVE, erlang, exit, [AccPid,kill]),
     [] = gen_rpc:nodes(),
     [] = supervisor:which_children(gen_rpc_client_sup),
     [] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_acceptor_sup]),


### PR DESCRIPTION
- Stop the gen_rpc_server after a connection has been handed off to the
  acceptor
- Update integration tests with a TCP close test
- Added Erlang Factory 2016 talk
- Removed exit trapping from dispatcher