### PR TITLE
Implement configurable remote TCP listener ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,16 +69,12 @@ COVERDATA = $(CURDIR)/_build/test/ct.coverdata
 # ======================
 ifneq ($(shell which docker 2> /dev/null),)
 
-ifeq ($(shell which jq 2> /dev/null),)
-	$(error "JQ is required to run integration tests on this system")
-endif
-
 NODES ?= 3
-IMAGE = $(shell docker images -q gen_rpc/integration 2> /dev/null)
+IMAGE = $(shell docker images -q gen_rpc:integration 2> /dev/null)
 
 image:
 ifeq ($(IMAGE),)
-	@cd test/integration && docker build --rm --pull -t gen_rpc/integration .
+	@cd test/integration && docker build --rm --pull -t gen_rpc:integration .
 endif
 
 integration: image

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ by running the command:
 
     make integration
 
-This will launch 3 slave containers and 1 master (change that by `NODES=5 make integration`) and will run the
-`integration_SUITE` CT test suite. The command needs [**jq**](https://stedolan.github.io/jq) in your `${PATH}` environment variable.
+This will launch 3 slave containers and 1 master (change that by `NODES=5 make integration`) and will run the `integration_SUITE` CT test suite.
 
 ## API
 
@@ -152,6 +151,9 @@ For more information on what the functions below do, run `erl -man rpc`.
 ### Application settings
 
 - `tcp_server_port`: The port in which the TCP listener service listens for incoming client requests.
+
+- `remote_tcp_server_ports`: A proplist with the nodes that run on alternative `tcp_server_port` configuration and the port
+  they have configured `gen_rpc` to listen to. Useful when running multiple nodes on the same system and you get port clashes.
 
 - `connect_timeout`: Default timeout for the initial node-to-node connection in **milliseconds**.
 

--- a/TODO.md
+++ b/TODO.md
@@ -7,4 +7,3 @@ This is a list of pending features or code technical debt for `gen_rpc`:
 - Implement per-id-and-node tuple connection sharing to spread workload on multiple mailboxes per node
 - Implement sbcast and abcast support
 - Implement static port range allocation (instead of listening to 0) to adhere to potential corporate firewall rules
-- Implement support for client-configurable TCP port per node in case multiple `gen_rpc` nodes are running on the same server.

--- a/src/gen_rpc.app.src
+++ b/src/gen_rpc.app.src
@@ -6,7 +6,7 @@
 
 {application, gen_rpc,
     [{description, "A scalable RPC library for Erlang-VM based languages"},
-    {vsn, "1.0.0"},
+    {vsn, "1.0.1"},
     {mod, {gen_rpc_app, []}},
     {registered, [gen_rpc_dispatcher, gen_rpc_listener]},
     {maintainers, ["Panagiotis PJ Papadomitsos"]},
@@ -24,6 +24,8 @@
     {env,[
         %% Default TCP listener port
         {tcp_server_port, 5369},
+        %% Proplist of nodes that listen to a different port
+        {remote_tcp_server_ports, []},
         %% Client connect timeout
         {connect_timeout, 5000},
         %% Client and Server send timeout

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -55,6 +55,7 @@ set_socket(Pid, Socket) when is_pid(Pid), is_port(Socket) ->
 %%% Behaviour callbacks
 %%% ===================================================
 init({Peer}) ->
+    _OldVal = erlang:process_flag(trap_exit, true),
     ok = lager:info("event=start peer=\"~s\"", [gen_rpc_helper:peer_to_string(Peer)]),
     %% Store the client's IP and the node in our state
     {ok, waiting_for_socket, #state{peer=Peer}}.
@@ -143,11 +144,11 @@ handle_info(Msg, StateName, State) ->
     ok = lager:critical("socket=\"~p\" event=uknown_event action=stopping", [State#state.socket]),
     {stop, {StateName, unknown_message, Msg}, State}.
 
-code_change(_OldVsn, StateName, State, _Extra) ->
-    {ok, StateName, State}.
-
 terminate(_Reason, _StateName, _State) ->
     ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
 
 %%% ===================================================
 %%% Private functions

--- a/src/gen_rpc_helper.erl
+++ b/src/gen_rpc_helper.erl
@@ -19,7 +19,7 @@
         set_sock_opt/2,
         make_process_name/2,
         extract_node_name/1,
-        get_tcp_server_port/0,
+        get_remote_tcp_server_port/1,
         get_connect_timeout/0,
         get_send_timeout/1,
         get_receive_timeout/1,
@@ -123,10 +123,22 @@ get_connect_timeout() ->
     {ok, ConnTO} = application:get_env(?APP, connect_timeout),
     ConnTO.
 
--spec get_tcp_server_port() -> inet:port_number().
-get_tcp_server_port() ->
-    {ok, Port} = application:get_env(?APP, tcp_server_port),
-    Port.
+%% Retrieves the specific TCP server port
+-spec get_remote_tcp_server_port(atom()) -> inet:port_number().
+get_remote_tcp_server_port(Node) ->
+    case application:get_env(?APP, remote_tcp_server_ports) of
+        {ok, []} ->
+            {ok, Port} = application:get_env(?APP, tcp_server_port),
+            Port;
+        {ok, Ports} ->
+            case lists:keyfind(Node, 1, Ports) of
+                false ->
+                    {ok, Port} = application:get_env(?APP, tcp_server_port),
+                    Port;
+                {Node, Port} ->
+                    Port
+            end
+    end.
 
 %% Merges user-defined receive timeout values with app timeout values
 -spec get_receive_timeout(undefined | timeout()) -> timeout().

--- a/src/gen_rpc_server.erl
+++ b/src/gen_rpc_server.erl
@@ -54,7 +54,7 @@ get_port(Pid) when is_pid(Pid) ->
 %%% Behaviour callbacks
 %%% ===================================================
 init({Peer}) ->
-    _OldVal = process_flag(trap_exit, true),
+    _OldVal = erlang:process_flag(trap_exit, true),
     case gen_tcp:listen(0, gen_rpc_helper:default_tcp_opts(?DEFAULT_TCP_OPTS)) of
         {ok, Socket} ->
             ok = lager:info("event=listener_started_successfully peer=\"~s\"",
@@ -124,9 +124,7 @@ handle_info(Msg, State) ->
     ok = lager:critical("event=uknown_message_received socket=\"~p\" message=\"~p\" action=stopping", [State#state.socket, Msg]),
     {stop, {unknown_message, Msg}, State}.
 
-%% Terminate cleanly by closing the listening socket
-terminate(_Reason, #state{socket=Socket}) ->
-    ok = lager:debug("socket=\"~p\"", [Socket]),
+terminate(_Reason, _State) ->
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/gen_rpc_tcp_acceptor.erl
+++ b/src/gen_rpc_tcp_acceptor.erl
@@ -57,6 +57,7 @@ set_socket(Pid, Socket) when is_pid(Pid), is_port(Socket) ->
 %%% Behaviour callbacks
 %%% ===================================================
 init({Peer}) ->
+    _OldVal = erlang:process_flag(trap_exit, true),
     ok = lager:debug("event=start peer=\"~s\"", [gen_rpc_helper:peer_to_string(Peer)]),
     %% Store the client's IP in our state
     {ok, waiting_for_socket, #state{peer=Peer}}.

--- a/src/gen_rpc_tcp_server.erl
+++ b/src/gen_rpc_tcp_server.erl
@@ -41,6 +41,7 @@ stop() ->
 %%% Behaviour callbacks
 %%% ===================================================
 init({}) ->
+    _OldVal = erlang:process_flag(trap_exit, true),
     {ok, Port} = application:get_env(?APP, tcp_server_port),
     case gen_tcp:listen(Port, gen_rpc_helper:default_tcp_opts(?DEFAULT_TCP_OPTS)) of
         {ok, Socket} ->

--- a/test/ct/integration_SUITE.erl
+++ b/test/ct/integration_SUITE.erl
@@ -67,8 +67,9 @@ remote_socket_close(_Config) ->
     Peers = peers(),
     ok = lists:foreach(fun(Node) ->
         [{_,AccPid,_,_}] = rpc:call(Node, supervisor, which_children, [gen_rpc_acceptor_sup]),
-        true = rpc:call(Node, erlang, exit, [AccPid,kill])
+        true = rpc:call(Node, erlang, exit, [AccPid,normal])
     end, peers()),
+    ok = timer:sleep(100),
     Alive = gen_rpc:nodes(),
     ok = lists:foreach(fun(Node) ->
         false = lists:member(Node, Alive)

--- a/test/ct/remote_SUITE.erl
+++ b/test/ct/remote_SUITE.erl
@@ -35,7 +35,6 @@ init_per_testcase(client_inactivity_timeout, Config) ->
     ok = gen_rpc_test_helper:restart_application(),
     ok = gen_rpc_test_helper:set_application_environment(),
     %% In order to connect to the slave
-    ok = application:set_env(?APP, tcp_server_port, 5370),
     ok = application:set_env(?APP, client_inactivity_timeout, 500),
     ok = gen_rpc_test_helper:start_slave(?SLAVE, 5370),
     Config;
@@ -44,7 +43,6 @@ init_per_testcase(server_inactivity_timeout, Config) ->
     ok = gen_rpc_test_helper:restart_application(),
     ok = gen_rpc_test_helper:set_application_environment(),
     %% In order to connect to the slave
-    ok = application:set_env(?APP, tcp_server_port, 5370),
     ok = gen_rpc_test_helper:start_slave(?SLAVE, 5370),
     ok = rpc:call(?SLAVE, application, set_env, [?APP, server_inactivity_timeout, 500]),
     Config;
@@ -53,21 +51,21 @@ init_per_testcase(_OtherTest, Config) ->
     ok = gen_rpc_test_helper:restart_application(),
     ok = gen_rpc_test_helper:set_application_environment(),
     %% In order to connect to the slave
-    ok = application:set_env(?APP, tcp_server_port, 5370),
     ok = gen_rpc_test_helper:start_slave(?SLAVE, 5370),
     Config.
 
 end_per_testcase(client_inactivity_timeout, Config) ->
     ok = gen_rpc_test_helper:stop_slave(?SLAVE),
     ok = application:set_env(?APP, client_inactivity_timeout, infinity),
-    ok = gen_rpc_test_helper:restart_application(),
-    ok = gen_rpc_test_helper:set_application_environment(),
+    Config;
+
+end_per_testcase(server_inactivity_timeout, Config) ->
+    ok = gen_rpc_test_helper:stop_slave(?SLAVE),
+    ok = application:set_env(?APP, server_inactivity_timeout, infinity),
     Config;
 
 end_per_testcase(_OtherTest, Config) ->
     ok = gen_rpc_test_helper:stop_slave(?SLAVE),
-    ok = gen_rpc_test_helper:restart_application(),
-    ok = gen_rpc_test_helper:set_application_environment(),
     Config.
 
 %%% ===================================================
@@ -214,6 +212,7 @@ random_remote_tcp_close(_Config) ->
     {_Mega, _Sec, _Micro} = gen_rpc:call(?SLAVE, os, timestamp),
     [{_,AccPid,_,_}] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_acceptor_sup]),
     true = rpc:call(?SLAVE, erlang, exit, [AccPid,kill]),
+    ok = timer:sleep(100),
     [] = gen_rpc:nodes(),
     [] = supervisor:which_children(gen_rpc_client_sup),
     [] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_acceptor_sup]),

--- a/test/gen_rpc.coverspec
+++ b/test/gen_rpc.coverspec
@@ -1,4 +1,4 @@
-{nodes, ['gen_rpc_master@127.0.0.1', 'gen_rpc_slave1@127.0.0.1', 'gen_rpc_slave2@127.0.0.1', 'nonode@nohost']}.
+{nodes, ['gen_rpc_master@127.0.0.1', 'gen_rpc_slave1@127.0.0.1']}.
 {export, "../_build/test/cover/ct.coverdata"}.
 {level, details}.
 {incl_dirs_r, ["../src"]}.

--- a/test/include/ct.hrl
+++ b/test/include/ct.hrl
@@ -12,14 +12,15 @@
 %%% Node definitions
 -define(NODE, 'gen_rpc_master@127.0.0.1').
 -define(SLAVE, 'gen_rpc_slave@127.0.0.1').
--define(SLAVE1, 'gen_rpc_slave1@127.0.0.1').
--define(SLAVE2, 'gen_rpc_slave2@127.0.0.1').
 
 -define(FAKE_NODE, 'fake_node@1.2.3.4').
 -define(TEST_APPLICATION_ENV, [{sasl, errlog_type, error},
         {sasl, error_logger_mf_dir, false},
         {gen_rpc, connect_timeout, 500},
         {gen_rpc, send_timeout, 500},
+        {gen_rpc, remote_tcp_server_ports, [
+            {?SLAVE, 5370}
+        ]},
         {lager, colored, true},
         {lager, handlers, [
             % Commented out to reduce test output polution, uncomment during development

--- a/test/integration/integration-tests.sh
+++ b/test/integration/integration-tests.sh
@@ -10,9 +10,9 @@ NODES=""
 start_node() {
 	export NAME=gen_rpc_${1}
 	echo -n "Starting container ${NAME}: "
-	docker run -i -t -d --privileged --name ${NAME} -P gen_rpc/integration
+	docker run -i -t -d --privileged --name ${NAME} -P gen_rpc:integration
 	sleep 2
-	export IP=$(docker inspect ${NAME} | jq -r ".[0].NetworkSettings.Networks.bridge.IPAddress")
+	export IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' ${NAME})
 	export NODES="${IP}:${NODES}"
 	docker exec ${NAME} epmd -daemon
 	docker exec -t -i ${NAME} bash -c "echo gen_rpc > ~/.erlang.cookie"
@@ -27,9 +27,9 @@ start_node() {
 start_master() {
 	export NAME=gen_rpc_master
 	echo -n "Starting container ${NAME}: "
-	docker run -i -t -d --privileged --name ${NAME} -P gen_rpc/integration
+	docker run -i -t -d --privileged --name ${NAME} -P gen_rpc:integration
 	sleep 2
-	export IP=$(docker inspect gen_rpc_master | jq -r ".[0].NetworkSettings.Networks.bridge.IPAddress")
+	export IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' gen_rpc_master)
 	docker exec ${NAME} epmd -daemon
 	docker exec -t -i ${NAME} bash -c "echo gen_rpc > ~/.erlang.cookie"
 	docker exec -t -i ${NAME} bash -c "chmod 600 ~/.erlang.cookie"


### PR DESCRIPTION
- Add remote_tcp_server_ports proplist support for configurable remote
  gen_rpc TCP listener ports
- Update documentation for above feature
- Update tests for above feature
- Add Erlang 18.3 to Travis
- Cleanup slave nodes
- Remove jq dependency for integration tests