### PR TITLE
Convert gen_fsm to gen_statem, Erlang 19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _plt
 logs
 _build
 rebar3
+*.crashdump

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This message essentially means that the VM's distributed port pair was busy whil
 
 To build this project you need to have the following:
 
-* **Erlang/OTP** >= 17.0
+* **Erlang/OTP** >= 19.0
 
 * **git** >= 1.7
 

--- a/include/app.hrl
+++ b/include/app.hrl
@@ -10,6 +10,7 @@
 -define(DEFAULT_TCP_OPTS, [binary,
         {packet,4},
         {exit_on_close,true},
+        {show_econnreset, true}, % Send message for reset connections
         {nodelay,true}, % Send our requests immediately
         {send_timeout_close,true}, % When the socket times out, close the connection
         {delay_send,false}, % Scheduler should favor timely delivery
@@ -27,6 +28,7 @@
 
 %%% The TCP options that should be copied from the listener to the acceptor
 -define(ACCEPTOR_TCP_OPTS, [nodelay,
+        show_econnreset,
         send_timeout_close,
         delay_send,
         linger,

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 %%%
 
 %%% Require OTP 17.0 at a bare minimum
-{require_min_otp_vsn, "17"}.
+{require_min_otp_vsn, "19"}.
 
 %% Plugins
 {plugins, [rebar3_hex]}.

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -10,7 +10,7 @@
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% Behaviour
--behaviour(gen_fsm).
+-behaviour(gen_statem).
 
 %%% Include this library's name macro
 -include("app.hrl").
@@ -28,12 +28,11 @@
 %%% Server functions
 -export([start_link/1, set_socket/2, stop/1]).
 
-%% gen_fsm callbacks
--export([init/1, handle_event/3, handle_sync_event/4,
-        handle_info/3, terminate/3, code_change/4]).
+%% gen_statem callbacks
+-export([init/1, handle_event/4, terminate/3, code_change/4]).
 
 %% FSM States
--export([waiting_for_socket/2, waiting_for_data/2]).
+-export([waiting_for_socket/3, waiting_for_data/3]).
 
 %%% Process exports
 -export([call_worker/6, call_middleman/3]).
@@ -41,26 +40,27 @@
 %%% ===================================================
 %%% Supervisor functions
 %%% ===================================================
--spec start_link({inet:ip4_address(), inet:port_number()}) -> gen_fsm:startlink_ret().
+-spec start_link({inet:ip4_address(), inet:port_number()}) -> gen_statem:startlink_ret().
 start_link(Peer) when is_tuple(Peer) ->
     Name = gen_rpc_helper:make_process_name("acceptor", Peer),
-    gen_fsm:start_link({local,Name}, ?MODULE, {Peer}, [{spawn_opt, [{priority, high}]}]).
+    gen_statem:start_link({local,Name}, ?MODULE, {Peer}, []).
 
 -spec stop(pid()) -> ok.
 stop(Pid) when is_pid(Pid) ->
-     gen_fsm:sync_send_all_state_event(Pid, stop).
+    gen_statem:stop(Pid, normal, infinity).
 
 %%% ===================================================
 %%% Server functions
 %%% ===================================================
 -spec set_socket(pid(), gen_tcp:socket()) -> ok.
 set_socket(Pid, Socket) when is_pid(Pid), is_port(Socket) ->
-    gen_fsm:send_event(Pid, {socket_ready, Socket}).
+    gen_statem:call(Pid, {socket_ready, Socket}, infinity).
 
 %%% ===================================================
 %%% Behaviour callbacks
 %%% ===================================================
 init({Peer}) ->
+    ok = gen_rpc_helper:set_optimal_process_flags(),
     {Control, ControlList} = case application:get_env(?APP, rpc_module_control) of
         {ok, undefined} ->
             {undefined, undefined};
@@ -68,20 +68,19 @@ init({Peer}) ->
             {ok, List} = application:get_env(?APP, rpc_module_list),
             {Type, sets:from_list(List)}
     end,
-    _OldVal = erlang:process_flag(trap_exit, true),
     ok = lager:info("event=start peer=\"~s\"", [gen_rpc_helper:peer_to_string(Peer)]),
     %% Store the client's IP and the node in our state
-    {ok, waiting_for_socket, #state{peer=Peer,control=Control,list=ControlList}}.
+    {state_functions, waiting_for_socket, #state{peer=Peer,control=Control,list=ControlList}}.
 
-waiting_for_socket({socket_ready, Socket}, #state{peer=Peer} = State) ->
+waiting_for_socket({call, From}, {socket_ready, Socket}, #state{peer=Peer} = State) ->
     % Now we own the socket
     ok = lager:debug("event=acquiring_socket_ownership socket=\"~p\" peer=\"~p\"",
                      [Socket, gen_rpc_helper:peer_to_string(Peer)]),
-    ok = inet:setopts(Socket, [{send_timeout, gen_rpc_helper:get_send_timeout(undefined)}|
-                      gen_rpc_helper:default_tcp_opts(?ACCEPTOR_DEFAULT_TCP_OPTS)]),
+    ok = inet:setopts(Socket, [{send_timeout, gen_rpc_helper:get_send_timeout(undefined)}|?ACCEPTOR_DEFAULT_TCP_OPTS]),
+    ok = gen_statem:reply(From, ok),
     {next_state, waiting_for_data, State#state{socket=Socket}}.
 
-waiting_for_data({data, Data}, #state{socket=Socket,peer=Peer,control=Control,list=List} = State) ->
+waiting_for_data(info, {tcp, Socket, Data}, #state{socket=Socket,peer=Peer,control=Control,list=List} = State) ->
     %% The meat of the whole project: process a function call and return
     %% the data
     try erlang:binary_to_term(Data) of
@@ -92,11 +91,11 @@ waiting_for_data({data, Data}, #state{socket=Socket,peer=Peer,control=Control,li
                     ok = lager:debug("event=call_received socket=\"~p\" peer=\"~s\" caller=\"~p\" worker_pid=\"~p\"",
                                      [Socket, gen_rpc_helper:peer_to_string(Peer), Caller, WorkerPid]),
                     ok = inet:setopts(Socket, [{active, once}]),
-                    {next_state, waiting_for_data, State, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
+                    {keep_state_and_data, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
                 false ->
                     ok = lager:debug("event=request_not_allowed socket=\"~p\" control=~s method=~s module=\"~s\"", [Socket,Control,CallType,M]),
                     ok = inet:setopts(Socket, [{active, once}]),
-                    handle_info({CallType, Caller, {badrpc,unauthorized}}, waiting_for_data, State)
+                    waiting_for_data(info, {CallType, Caller, {badrpc,unauthorized}}, State)
             end;
         {cast, M, F, A} ->
             case is_allowed(M, Control, List) of
@@ -105,18 +104,18 @@ waiting_for_data({data, Data}, #state{socket=Socket,peer=Peer,control=Control,li
                                      [Socket, gen_rpc_helper:peer_to_string(Peer), M, F, A]),
                     _Pid = erlang:spawn(M, F, A),
                     ok = inet:setopts(Socket, [{active, once}]),
-                    {next_state, waiting_for_data, State, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
+                    {keep_state_and_data, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
                 false ->
                     ok = lager:debug("event=request_not_allowed socket=\"~p\" control=~s method=cast module=\"~s\"", [Socket,Control,M]),
                     ok = inet:setopts(Socket, [{active, once}]),
-                    {next_state, waiting_for_data, State, gen_rpc_helper:get_inactivity_timeout(?MODULE)}
+                    {keep_state_and_data, gen_rpc_helper:get_inactivity_timeout(?MODULE)}
             end;
         {abcast, Name, Msg} ->
             ok = lager:debug("event=abcast_received socket=\"~p\" peer=\"~s\" process=~s message=\"~p\"",
                              [Socket, gen_rpc_helper:peer_to_string(Peer), Name, Msg]),
             Msg = erlang:send(Name, Msg),
             ok = inet:setopts(Socket, [{active, once}]),
-            {next_state, waiting_for_data, State, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
+            {keep_state_and_data, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
         {sbcast, Name, Msg, Caller} ->
             ok = lager:debug("event=sbcast_received socket=\"~p\" peer=\"~s\" process=~s message=\"~p\"",
                              [Socket, gen_rpc_helper:peer_to_string(Peer), Name, Msg]),
@@ -125,7 +124,7 @@ waiting_for_data({data, Data}, #state{socket=Socket,peer=Peer,control=Control,li
                 Pid -> Pid ! Msg, success
             end,
             ok = inet:setopts(Socket, [{active, once}]),
-            handle_info({sbcast, Caller, Reply}, waiting_for_data, State);
+            waiting_for_data(info, {sbcast, Caller, Reply}, State);
         OtherData ->
             ok = lager:debug("event=erroneous_data_received socket=\"~p\" peer=\"~s\" data=\"~p\"",
                              [Socket, gen_rpc_helper:peer_to_string(Peer), OtherData]),
@@ -135,63 +134,46 @@ waiting_for_data({data, Data}, #state{socket=Socket,peer=Peer,control=Control,li
             {stop, {badtcp, corrupt_data}, State}
     end;
 
-%% Handle the inactivity timeout gracefully
-waiting_for_data(timeout, State) ->
-    ok = lager:info("message=timeout event=server_inactivity_timeout socket=\"~p\" action=stopping", [State#state.socket]),
-    {stop, normal, State}.
-
-handle_event(Event, StateName, State) ->
-    ok = lager:critical("socket=\"~p\" event=uknown_event payload=\"~p\" action=stopping", [State#state.socket, Event]),
-    {stop, {StateName, undefined_event, Event}, State}.
-
-%% Gracefully terminate
-handle_sync_event(stop, _From, _StateName, State) ->
-    ok = lager:debug("message=stop event=stopping_acceptor socket=\"~p\"", [State#state.socket]),
-    {stop, normal, ok, State};
-
-handle_sync_event(Event, _From, StateName, State) ->
-    ok = lager:critical("event=uknown_event socket=\"~p\" payload=\"~p\" action=stopping", [State#state.socket, Event]),
-    {stop, {StateName, undefined_event, Event}, State}.
-
-%% Incoming data handlers
-handle_info({tcp, Socket, Data}, waiting_for_data, #state{socket=Socket} = State) when Socket =/= undefined ->
-    waiting_for_data({data, Data}, State);
-
 %% Handle a call worker message
-handle_info({CallReply, _Caller, _Reply} = Payload, waiting_for_data, #state{socket=Socket} = State) when Socket =/= undefined, CallReply =:= call;
-                                                                                                          Socket =/= undefined, CallReply =:= async_call;
-                                                                                                          Socket =/= undefined, CallReply =:= sbcast ->
+waiting_for_data(info, {CallReply,_Caller,_Reply} = Payload, #state{socket=Socket} = State) when Socket =/= undefined, CallReply =:= call;
+                                                                                                 Socket =/= undefined, CallReply =:= async_call;
+                                                                                                 Socket =/= undefined, CallReply =:= sbcast ->
     Packet = erlang:term_to_binary(Payload),
     ok = lager:debug("message=call_reply event=call_reply_received socket=\"~p\" type=~s", [Socket, CallReply]),
     case gen_tcp:send(Socket, Packet) of
         ok ->
             ok = lager:debug("message=call_reply event=call_reply_sent socket=\"~p\"", [Socket]),
-            {next_state, waiting_for_data, State, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
+            {keep_state_and_data, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
         {error, Reason} ->
             ok = lager:error("message=call_reply event=failed_to_send_call_reply socket=\"~p\" reason=\"~p\"", [Socket, Reason]),
             {stop, {badtcp, Reason}, State}
     end;
 
-handle_info({tcp_closed, Socket}, _StateName, #state{socket=Socket,peer=Peer} = State) ->
+%% Handle the inactivity timeout gracefully
+waiting_for_data(timeout, _Undefined, State) ->
+    ok = lager:info("message=timeout event=server_inactivity_timeout socket=\"~p\" action=stopping", [State#state.socket]),
+    {stop, normal, State}.
+
+handle_event(info, {tcp_closed, Socket}, _StateName, #state{socket=Socket,peer=Peer} = State) ->
     ok = lager:notice("message=tcp_closed event=tcp_socket_closed socket=\"~p\" peer=\"~s\" action=stopping",
                       [Socket, gen_rpc_helper:peer_to_string(Peer)]),
     {stop, normal, State};
 
-handle_info({tcp_error, Socket, Reason}, _StateName, #state{socket=Socket,peer=Peer} = State) ->
+handle_event(info, {tcp_error, Socket, Reason}, _StateName, #state{socket=Socket,peer=Peer} = State) ->
     ok = lager:notice("message=tcp_error event=tcp_socket_error socket=\"~p\" peer=\"~s\" reason=\"~p\" action=stopping",
                       [Socket, gen_rpc_helper:peer_to_string(Peer), Reason]),
     {stop, normal, State};
 
-%% Catch-all for info - our protocol is strict so die!
-handle_info(Msg, StateName, State) ->
-    ok = lager:critical("socket=\"~p\" event=uknown_event action=stopping", [State#state.socket]),
-    {stop, {StateName, unknown_message, Msg}, State}.
+handle_event(EventType, Event, StateName, State) ->
+    ok = lager:critical("socket=\"~p\" event=uknown_event event_type=\"~p\" payload=\"~p\" action=stopping",
+                        [State#state.socket, EventType, Event]),
+    {stop, {StateName, undefined_event, Event}, State}.
 
 terminate(_Reason, _StateName, _State) ->
     ok.
 
 code_change(_OldVsn, StateName, State, _Extra) ->
-    {ok, StateName, State}.
+    {state_functions, StateName, State}.
 
 %%% ===================================================
 %%% Private functions

--- a/src/gen_rpc_dispatcher.erl
+++ b/src/gen_rpc_dispatcher.erl
@@ -33,7 +33,7 @@ start_link() ->
 
 -spec stop() -> ok.
 stop() ->
-    gen_server:call(?MODULE, stop, infinity).
+    gen_server:stop(?MODULE, normal, infinity).
 
 -spec start_client(node()) -> {ok, pid()} | {error, any()}.
 start_client(Node) when is_atom(Node) ->
@@ -59,10 +59,6 @@ handle_call({start_client, Node}, _Caller, undefined) ->
             {ok, Pid}
     end,
     {reply, Reply, undefined};
-
-%% Gracefully terminate
-handle_call(stop, _Caller, undefined) ->
-    {stop, normal, ok, undefined};
 
 %% Catch-all for calls - die if we get a message we don't expect
 handle_call(Msg, _Caller, undefined) ->

--- a/src/gen_rpc_tcp_acceptor.erl
+++ b/src/gen_rpc_tcp_acceptor.erl
@@ -10,7 +10,7 @@
 -author("Panagiotis Papadomitsos <pj@ezgr.net>").
 
 %%% Behaviour
--behaviour(gen_fsm).
+-behaviour(gen_statem).
 
 %%% Include this library's name macro
 -include("app.hrl").
@@ -27,31 +27,30 @@
 %%% Server functions
 -export([start_link/1, set_socket/2, stop/1]).
 
-%% gen_fsm callbacks
--export([init/1, handle_event/3, handle_sync_event/4,
-        handle_info/3, terminate/3, code_change/4]).
+%% gen_statem callbacks
+-export([init/1, handle_event/4, terminate/3, code_change/4]).
 
 %% FSM States
--export([waiting_for_socket/2, waiting_for_data/2]).
+-export([waiting_for_socket/3, waiting_for_data/3]).
 
 %%% ===================================================
 %%% Supervisor functions
 %%% ===================================================
--spec start_link({inet:ip4_address(), inet:port_number()}) -> gen_sever:startlink_ret().
+-spec start_link({inet:ip4_address(), inet:port_number()}) -> gen_statem:startlink_ret().
 start_link(Peer) when is_tuple(Peer) ->
     Name = gen_rpc_helper:make_process_name("tcp_acceptor", Peer),
-    gen_fsm:start_link({local,Name}, ?MODULE, {Peer}, []).
+    gen_statem:start_link({local,Name}, ?MODULE, {Peer}, []).
 
 -spec stop(pid()) -> ok.
 stop(Pid) when is_pid(Pid) ->
-     gen_fsm:sync_send_all_state_event(Pid, stop).
+     gen_statem:stop(Pid, normal, infinity).
 
 %%% ===================================================
 %%% Server functions
 %%% ===================================================
 -spec set_socket(pid(), gen_tcp:socket()) -> ok.
 set_socket(Pid, Socket) when is_pid(Pid), is_port(Socket) ->
-    gen_fsm:send_event(Pid, {socket_ready, Socket}).
+    gen_statem:call(Pid, {socket_ready, Socket}).
 
 %%% ===================================================
 %%% Behaviour callbacks
@@ -60,16 +59,17 @@ init({Peer}) ->
     _OldVal = erlang:process_flag(trap_exit, true),
     ok = lager:debug("event=start peer=\"~s\"", [gen_rpc_helper:peer_to_string(Peer)]),
     %% Store the client's IP in our state
-    {ok, waiting_for_socket, #state{peer=Peer}}.
+    {state_functions, waiting_for_socket, #state{peer=Peer}}.
 
-waiting_for_socket({socket_ready, Socket}, #state{peer=Peer} = State) ->
+waiting_for_socket({call, From}, {socket_ready, Socket}, #state{peer=Peer} = State) ->
     % Now we own the socket
     ok = lager:debug("event=acquiring_socket_ownership socket=\"~p\" peer=\"~s\"", [Socket, gen_rpc_helper:peer_to_string(Peer)]),
-    ok = inet:setopts(Socket, [{send_timeout, ?SEND_TIMEOUT}|gen_rpc_helper:default_tcp_opts(?ACCEPTOR_DEFAULT_TCP_OPTS)]),
+    ok = inet:setopts(Socket, [{send_timeout, ?SEND_TIMEOUT}|?ACCEPTOR_DEFAULT_TCP_OPTS]),
+    ok = gen_statem:reply(From, ok),
     {next_state, waiting_for_data, State#state{socket=Socket}}.
 
 %% Notification event coming from client
-waiting_for_data({data, Data}, #state{socket=Socket, peer=Peer} = State) ->
+waiting_for_data(info, {tcp, Socket, Data}, #state{socket=Socket,peer=Peer} = State) when Socket =/= undefined ->
     Cookie = erlang:get_cookie(),
     try erlang:binary_to_term(Data) of
         {start_gen_rpc_server, ClientCookie} when ClientCookie =:= Cookie ->
@@ -80,14 +80,14 @@ waiting_for_data({data, Data}, #state{socket=Socket, peer=Peer} = State) ->
                 {error, Reason} ->
                     ok = lager:error("event=transmission_failed socket=\"~p\" peer=\"~s\" reason=\"~p\"",
                                      [Socket, gen_rpc_helper:peer_to_string(Peer), Reason]),
-                    {stop, {badtcp,Reason}, {badtcp,Reason}, State};
+                    {stop, {badtcp,Reason}, State};
                 ok ->
                     ok = lager:debug("event=transmission_succeeded socket=\"~p\" peer=\"~s\"",
                                      [Socket, gen_rpc_helper:peer_to_string(Peer)]),
                     {stop, normal, State}
             end,
             Result;
-        {start_gen_rpc_server, _CorrrectClientCookie} ->
+        {start_gen_rpc_server, _IncorrectClientCookie} ->
             ok = lager:error("event=invalid_cookie_received socket=\"~p\" peer=\"~s\"",
                              [Socket, gen_rpc_helper:peer_to_string(Peer)]),
             Packet = erlang:term_to_binary({connection_rejected, invalid_cookie}),
@@ -99,7 +99,7 @@ waiting_for_data({data, Data}, #state{socket=Socket, peer=Peer} = State) ->
                     ok = lager:debug("event=transmission_succeeded socket=\"~p\" peer=\"~s\"",
                                      [Socket, gen_rpc_helper:peer_to_string(Peer)])
             end,
-            {stop, {badrpc,invalid_cookie}, {badrpc,invalid_cookie}, State};
+            {stop, {badrpc,invalid_cookie}, State};
         OtherData ->
             ok = lager:debug("event=erroneous_data_received socket=\"~p\" peer=\"~s\" data=\"~p\"",
                              [Socket, gen_rpc_helper:peer_to_string(Peer), OtherData]),
@@ -110,44 +110,27 @@ waiting_for_data({data, Data}, #state{socket=Socket, peer=Peer} = State) ->
     end;
 
 %% Handle the inactivity timeout gracefully
-waiting_for_data(timeout, State) ->
+waiting_for_data(timeout, _Undefined, State) ->
     ok = lager:info("message=timeout event=receive_timeout socket=\"~p\" action=stopping", [State#state.socket]),
     {stop, normal, State}.
 
-handle_event(Event, StateName, State) ->
-    ok = lager:critical("socket=\"~p\" event=uknown_event payload=\"~p\" action=stopping", [State#state.socket, Event]),
-    {stop, {StateName, undefined_event, Event}, State}.
-
-%% Gracefully terminate
-handle_sync_event(stop, _From, _StateName, State) ->
-    ok = lager:debug("message=stop event=stopping_acceptor socket=\"~p\"", [State#state.socket]),
-    {stop, normal, ok, State};
-
-handle_sync_event(Event, _From, StateName, State) ->
-    ok = lager:critical("event=uknown_event socket=\"~p\" payload=\"~p\" action=stopping", [State#state.socket, Event]),
-    {stop, {StateName, undefined_event, Event}, State}.
-
-%% Incoming data handlers
-handle_info({tcp, Socket, Data}, waiting_for_data, #state{socket=Socket} = State) when Socket =/= undefined ->
-    waiting_for_data({data, Data}, State);
-
-handle_info({tcp_closed, Socket}, _StateName, #state{socket=Socket, peer=Peer} = State) ->
+handle_event(info, {tcp_closed, Socket}, _StateName, #state{socket=Socket, peer=Peer} = State) ->
     ok = lager:info("message=tcp_closed event=tcp_socket_closed socket=\"~p\" peer=\"~s\" action=stopping",
                       [Socket, gen_rpc_helper:peer_to_string(Peer)]),
     {stop, normal, State};
 
-handle_info({tcp_error, Socket, Reason}, _StateName, #state{socket=Socket,peer=Peer} = State) ->
+handle_event(info, {tcp_error, Socket, Reason}, _StateName, #state{socket=Socket,peer=Peer} = State) ->
     ok = lager:notice("message=tcp_error event=tcp_socket_error socket=\"~p\" peer=\"~s\" reason=\"~p\" action=stopping",
                       [Socket, gen_rpc_helper:peer_to_string(Peer), Reason]),
     {stop, normal, State};
 
-%% Catch-all for info - our protocol is strict so die!
-handle_info(Msg, StateName, State) ->
-    ok = lager:critical("socket=\"~p\" event=uknown_event action=stopping", [State#state.socket]),
-    {stop, {StateName, unknown_message, Msg}, State}.
+handle_event(EventType, Event, StateName, State) ->
+    ok = lager:critical("socket=\"~p\" event=uknown_event event_type=\"~p\" payload=\"~p\" action=stopping",
+                        [State#state.socket, EventType, Event]),
+    {stop, {StateName, undefined_event, Event}, State}.
 
 code_change(_OldVsn, StateName, State, _Extra) ->
-    {ok, StateName, State}.
+    {state_functions, StateName, State}.
 
 terminate(_Reason, _StateName, _State) ->
     ok.

--- a/test/integration/Dockerfile
+++ b/test/integration/Dockerfile
@@ -1,7 +1,6 @@
 # Dockerfile to test gen_rpc via proper distributed nodes
 FROM ubuntu:xenial
 MAINTAINER Panagiotis PJ Papadomitsos <pj@ezgr.net>
-VOLUME "/gen_rpc"
 WORKDIR "/gen_rpc"
 ENV HOME=/root
 ENV TERM=xterm-256color

--- a/test/integration/integration-tests.sh
+++ b/test/integration/integration-tests.sh
@@ -17,7 +17,7 @@ start_node() {
 	docker exec ${NAME} epmd -daemon
 	docker exec -t -i ${NAME} bash -c "echo gen_rpc > ~/.erlang.cookie"
 	docker exec -t -i ${NAME} bash -c "chmod 600 ~/.erlang.cookie"
-	docker exec -t -i ${NAME} bash -c "rm -fr /gen_rpc/*"
+	docker exec -t -i ${NAME} bash -c "rm -fr /gen_rpc"
 	docker cp ../../ ${NAME}:/
 	docker exec -t -i ${NAME} bash -c "cd /gen_rpc && make"
 	docker exec -t -i -d ${NAME} bash -c "cd /gen_rpc && ./rebar3 as dev do shell --name gen_rpc@${IP}"
@@ -37,7 +37,7 @@ start_master() {
 	docker cp ../../ ${NAME}:/
 	docker exec -t -i ${NAME} bash -c "cd /gen_rpc && make"
 	echo Starting integration tests on container ${NAME}
-	docker exec -t -i gen_rpc_master bash -c "export NODES=${NODES} NODE=gen_rpc@${IP} && cd /gen_rpc && make && ./rebar3 as test do ct --suite integration_SUITE"
+	docker exec -t -i gen_rpc_master bash -c "export NODES=${NODES} NODE=gen_rpc@${IP} && cd /gen_rpc && make && ./rebar3 as test do ct --suite test/ct/integration_SUITE"
 }
 
 destroy() {


### PR DESCRIPTION
- Convert gen_rpc_acceptor and gen_rpc_tcp_acceptor to gen_statem
  following the release of Erlang 19
- Add optimization flags for off-process heap message queue
- Remove < Erlang 19 compatibility code
- Fix integration tests