### PR TITLE
Add compatibility with OTP21

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -28,12 +28,15 @@
     warn_unused_function,
     warn_bif_clash,
     warn_unused_record,
-    warn_exported_vars
+    warn_exported_vars,
+    {parse_transform, stacktrace_transform},
+    {platform_define, "^[2-9]", post19}
 ]}.
 
 {deps, [
     {hut, "~> 1.2"},
-    {ssl_verify_fun, "~> 1.1"}
+    {ssl_verify_fun, "~> 1.1"},
+    {stacktrace_compat, "~> 1.1.1"}
 ]}.
 
 {profiles, [

--- a/src/driver/gen_rpc_driver_ssl.erl
+++ b/src/driver/gen_rpc_driver_ssl.erl
@@ -65,12 +65,26 @@ listen(Port) when is_integer(Port) ->
 -spec accept(ssl:sslsocket()) -> ok | {error, term()}.
 accept(Socket) when is_tuple(Socket) ->
     {ok, TSocket} = ssl:transport_accept(Socket, infinity),
-    case ssl:ssl_accept(TSocket) of
-        ok ->
-            {ok, TSocket};
+    case upgrade_ssl_socket(TSocket) of
+        {ok, TLSSocket} ->
+            {ok, TLSSocket};
+        {error, Error} ->
+            Error
+    end.
+
+
+-ifdef(post19).
+upgrade_ssl_socket(Socket) ->
+    ssl:handshake(Socket).
+-else.
+upgrade_ssl_socket(Socket) ->
+    case ssl:ssl_accept(Socket) of 
+        ok -> 
+            {ok, Socket};
         Error ->
             Error
     end.
+-endif.
 
 -spec send(ssl:sslsocket(), binary()) -> ok | {error, term()}.
 send(Socket, Data) when is_tuple(Socket), is_binary(Data) ->


### PR DESCRIPTION
Patches compatibility to allow compilation and running under OTP21, while attempting not to break functionality. or minimum otp versions that were previously in effect.