### PR TITLE
Add tcp options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: erlang
 otp_release:
@@ -18,4 +19,3 @@ branches:
 notifications:
   email:
     - pj@ezgr.net
-

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ and pass them as the node list in the multi-node function.
 
 - `tcp_client_port`: The plain TCP port `gen_rpc` will use for outgoing connections.
 
+- `tcp_server_options` and `tcp_client_options`: Settings for the `tcp` driver that `gen_rpc` will use to
+  connect to a remote `gen_rpc` server.
+
 - `ssl_server_port`: The port `gen_rpc` will use for incoming SSL connections or `false` if you do not
   want SSL enabled.
 

--- a/src/gen_rpc.app.src
+++ b/src/gen_rpc.app.src
@@ -25,8 +25,12 @@
     {env,[
         %% TCP server port. Set to false to disable
         {tcp_server_port, 5369},
+        %% TCP server options
+        {tcp_server_options, []},
         %% Default TCP port for outgoing connections
         {tcp_client_port, 5369},
+        %% TCP client options
+        {tcp_client_options, []},
         %% SSL server port. Set to false to disable
         {ssl_server_port, false},
         %% SSL server options


### PR DESCRIPTION
This PR can set some tcp options such as `SO_REUSEPORT` that is not included in `TCP_DEFAULT_OPTS ` from APP configuration.