### PR TITLE
Update Travis CI Erlang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: false
 language: erlang
 otp_release:
-  - "19.1"
-  - "19.2"
+  - "19.3"
+  - "20.3"
 cache:
   directories:
-  - $HOME/otp/19.1
-  - $HOME/otp/19.2
+  - $HOME/otp/19.3
+  - $HOME/otp/20.3
   - $HOME/.cache/rebar3
   - _plt
 install: "true"
@@ -18,4 +18,3 @@ branches:
 notifications:
   email:
     - pj@ezgr.net
-


### PR DESCRIPTION
> Ubuntu Xenial 16.04 as the default Travis CI build environment

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment
https://docs.travis-ci.com/user/languages/erlang/#otprelease-versions

19.1 and 19.2 are not included in ubuntu 16.04 environment.